### PR TITLE
Replace retired gemini-3-pro-preview with gemini-3.1-pro-preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,7 +281,7 @@ AI_MODEL=gemini-2.5-flash
 |-------|-------------|
 | `gemini-2.5-flash` | Fast, cost-effective (default) |
 | `gemini-2.5-pro` | Higher quality |
-| `gemini-3-pro-preview` | Most intelligent (preview, may require allowlisting) |
+| `gemini-3.1-pro-preview` | Most intelligent (preview) |
 
 **Claude:**
 
@@ -313,7 +313,7 @@ The app automatically uses enhanced reasoning (thinking mode) for analytical ope
 |-----------|-----------|------------|
 | Interview responses | OFF | User-selected model |
 | Greeting generation | OFF | User-selected model |
-| Per-interview synthesis | ON (high) | Auto-upgraded (Gemini 3 Pro / Claude Opus) |
+| Per-interview synthesis | ON (high) | Auto-upgraded (Gemini 3.1 Pro / Claude Opus) |
 | Aggregate synthesis | ON (high) | Auto-upgraded |
 | Follow-up study generation | ON (high) | Auto-upgraded |
 
@@ -326,13 +326,13 @@ In Study Setup, you can override the default behavior:
 
 **Cost Implications:**
 - Synthesis operations automatically use premium models for best quality
-- Gemini: Uses `gemini-3-pro-preview` for synthesis
+- Gemini: Uses `gemini-3.1-pro-preview` for synthesis
 - Claude: Uses `claude-opus-4-5` ($15/$75 per MTok) for synthesis
 - Reasoning tokens count toward billing
 
 **Troubleshooting:**
 - If synthesis fails silently, check API quotas for premium models
-- `gemini-3-pro-preview` may require allowlisting in Google AI Studio
+- Preview model IDs are retired on short notice - Google shut down `gemini-3-pro-preview` on 2026-03-09. If synthesis 404s with "no longer available", the ID is dead: check [Google's model docs](https://ai.google.dev/gemini-api/docs/models) for the successor. Note that `GET /v1beta/models` is *not* a reliable check here - it kept listing `gemini-3-pro-preview` after the shutdown; only an actual `generateContent` call returns the 404
 - Claude Opus ($15/$75/MTok) is used for synthesis - monitor costs
 - Set reasoning to "Always disabled" if you want to use your selected model without upgrades
 

--- a/src/lib/providers/gemini.ts
+++ b/src/lib/providers/gemini.ts
@@ -61,12 +61,12 @@ export class GeminiProvider implements AIProvider {
     };
   }
 
-  // For synthesis operations (Gemini 3 Pro) - use thinkingLevel instead of thinkingBudget
+  // For synthesis operations (Gemini 3.1 Pro) - use thinkingLevel instead of thinkingBudget
   private getSynthesisThinkingConfig(enableReasoning?: boolean) {
     const useReasoning = enableReasoning !== false;
     return {
       thinkingConfig: {
-        // Gemini 3 Pro uses ThinkingLevel enum instead of thinkingBudget
+        // Gemini 3.1 Pro uses ThinkingLevel enum instead of thinkingBudget
         thinkingLevel: useReasoning ? ThinkingLevel.HIGH : ThinkingLevel.LOW
       }
     };

--- a/src/types.ts
+++ b/src/types.ts
@@ -68,7 +68,7 @@ export interface AIModelOption {
 export const GEMINI_MODELS: AIModelOption[] = [
   { id: 'gemini-2.5-flash', label: 'Gemini 2.5 Flash', desc: 'Fast, cost-effective' },
   { id: 'gemini-2.5-pro', label: 'Gemini 2.5 Pro', desc: 'Higher quality' },
-  { id: 'gemini-3-pro-preview', label: 'Gemini 3 Pro Preview', desc: 'Most intelligent (preview)' },
+  { id: 'gemini-3.1-pro-preview', label: 'Gemini 3.1 Pro Preview', desc: 'Most intelligent (preview)' },
 ];
 
 // Available Claude models (verified from official docs)
@@ -83,7 +83,7 @@ export const DEFAULT_GEMINI_MODEL = 'gemini-2.5-flash';
 export const DEFAULT_CLAUDE_MODEL = 'claude-sonnet-4-5';
 
 // Synthesis models (auto-upgrade to best available for reasoning tasks)
-export const GEMINI_SYNTHESIS_MODEL = 'gemini-3-pro-preview';
+export const GEMINI_SYNTHESIS_MODEL = 'gemini-3.1-pro-preview';
 export const CLAUDE_SYNTHESIS_MODEL = 'claude-opus-4-5';
 
 // Link expiration options


### PR DESCRIPTION
## The bug

Google shut down `gemini-3-pro-preview` on **2026-03-09**. Two code paths named it, so both were calling a dead model:

- `src/types.ts:71` - the `GEMINI_MODELS` dropdown entry, so a researcher could pick a model that 404s for interviews.
- `src/types.ts:86` - `GEMINI_SYNTHESIS_MODEL`, the auto-upgrade target for reasoning tasks. This is the worse one: **every** per-interview synthesis, aggregate synthesis, and follow-up study generation on Gemini upgraded itself straight into a 404.

## How this was verified

Against the **live API**, not from docs or memory - which matters, because the obvious check is the one that lies:

`GET /v1beta/models` **still advertises `gemini-3-pro-preview`** with `generateContent` in its supported methods, months after the shutdown. Listing the models tells you nothing. Only an actual call does:

| Model ID | `:generateContent` |
|---|---|
| `gemini-3-pro-preview` | **404 `NOT_FOUND`** - "This model models/gemini-3-pro-preview is no longer available. Please update your code to use a newer model." |
| `gemini-3.1-pro-preview` | **200** - returns a completion, `modelVersion: gemini-3.1-pro-preview` |
| `gemini-2.5-flash` | 200 |
| `gemini-2.5-pro` | 200 |

Corroborated by the Google AI Developers Forum migration notice ("Migrate from Gemini 3 Pro Preview to Gemini 3.1 Pro Preview before March 9, 2026"). Google's own deprecations page serves a bot captcha to non-browser clients, so the API was the authoritative source.

I also checked that the synthesis path still *works* on the new model, not just that the ID resolves: `getSynthesisThinkingConfig()` sends `thinkingLevel: HIGH` (the Gemini 3.x enum, not `thinkingBudget`), and `gemini-3.1-pro-preview` accepts it - 200, 95 thinking tokens. The reasoning upgrade keeps working.

## Changes

- `src/types.ts` - dropdown entry and `GEMINI_SYNTHESIS_MODEL` both move to `gemini-3.1-pro-preview`; label updated to "Gemini 3.1 Pro Preview".
- `src/lib/providers/gemini.ts` - two comments that named the old model family. No logic change: nothing branches on the model-ID string, so the rename is behavior-preserving.
- `README.md` - the three ID references, plus the troubleshooting note. The old note claimed the preview model "may require allowlisting in Google AI Studio"; that was never verified and 3.1 Pro answered a plain API key immediately, so it is replaced with the failure mode that actually bites: **preview IDs get retired on short notice, and the models-list endpoint lags the shutdown**, so a 404 is the real signal.

## Deliberately not changed

- `gemini-2.5-flash`, `gemini-2.5-pro` - both verified live.
- `claude-haiku-4-5`, `claude-sonnet-4-5`, `claude-opus-4-5` - all three still active, none retired.

## Verification run

`bun run build` passes (the repo's primary check per `CLAUDE.md` - it covers type errors and routes; there is no test suite).

`bun run lint` fails, but **it fails identically on a clean tree**: the repo has no ESLint config, so `next lint` drops into its interactive setup prompt and exits non-zero. Pre-existing and unrelated to this change; configuring ESLint felt out of scope for a model-ID fix.

## Caveat, stated rather than papered over

The Claude IDs were checked against Anthropic's current model catalog, **not** against a live `GET /v1/models` - there is no `ANTHROPIC_API_KEY` in this environment. The catalog says all three are still served, and none are in the retired list, so I left them alone under "only change what you have verified." A live check would be worth doing by someone holding a key.

Separately: the `claude-opus-4-5` desc/README both quote **$15/$75 per MTok**. I could not verify current Opus 4.5 pricing from a live source, so I did not touch it - flagging it as worth a look, since stale pricing in a UI is the same class of bug as a stale model ID.

🤖 Generated with [Claude Code](https://claude.com/claude-code)