### PR TITLE
Correct model pricing and synthesis copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,7 +281,7 @@ AI_MODEL=gemini-2.5-flash
 |-------|-------------|
 | `gemini-2.5-flash` | Fast, cost-effective (default) |
 | `gemini-2.5-pro` | Higher quality |
-| `gemini-3.1-pro-preview` | Most intelligent (preview) |
+| `gemini-3.1-pro-preview` | Higher capability (preview) |
 
 **Claude:**
 
@@ -289,9 +289,9 @@ AI_MODEL=gemini-2.5-flash
 |-------|-------------|---------|
 | `claude-haiku-4-5` | Fastest | $1/$5 per MTok |
 | `claude-sonnet-4-5` | Balanced (default) | $3/$15 per MTok |
-| `claude-opus-4-5` | Most capable | $15/$75 per MTok |
+| `claude-opus-4-5` | Higher capability | $5/$25 per MTok |
 
-**Note:** Preview models may require API access approval. Check [Google AI docs](https://ai.google.dev/gemini-api/docs/models) and [Anthropic docs](https://docs.anthropic.com/en/docs/about-claude/models) for the latest model availability.
+**Note:** Preview models may require API access approval. Check [Google AI docs](https://ai.google.dev/gemini-api/docs/models) and [Anthropic docs](https://platform.claude.com/docs/en/about-claude/models/overview) for the latest model availability.
 
 ### Optional: Claude for Interviews
 
@@ -313,9 +313,9 @@ The app automatically uses enhanced reasoning (thinking mode) for analytical ope
 |-----------|-----------|------------|
 | Interview responses | OFF | User-selected model |
 | Greeting generation | OFF | User-selected model |
-| Per-interview synthesis | ON (high) | Auto-upgraded (Gemini 3.1 Pro / Claude Opus) |
-| Aggregate synthesis | ON (high) | Auto-upgraded |
-| Follow-up study generation | ON (high) | Auto-upgraded |
+| Per-interview synthesis | ON (high) | Uses the configured synthesis model (Gemini 3.1 Pro / Claude Opus 4.5) |
+| Aggregate synthesis | ON (high) | Uses the configured synthesis model |
+| Follow-up study generation | ON (high) | Uses the configured synthesis model |
 
 **Per-Study Override:**
 
@@ -325,16 +325,16 @@ In Study Setup, you can override the default behavior:
 - **Always disabled**: Force reasoning OFF for all operations (faster but less thorough synthesis)
 
 **Cost Implications:**
-- Synthesis operations automatically use premium models for best quality
+- Synthesis operations use the app's configured higher-capability models
 - Gemini: Uses `gemini-3.1-pro-preview` for synthesis
-- Claude: Uses `claude-opus-4-5` ($15/$75 per MTok) for synthesis
+- Claude: Uses `claude-opus-4-5` ($5/$25 per MTok) for synthesis
 - Reasoning tokens count toward billing
 
 **Troubleshooting:**
-- If synthesis fails silently, check API quotas for premium models
+- If synthesis fails silently, check API quotas for the configured synthesis models
 - Preview model IDs are retired on short notice - Google shut down `gemini-3-pro-preview` on 2026-03-09. If synthesis 404s with "no longer available", the ID is dead: check [Google's model docs](https://ai.google.dev/gemini-api/docs/models) for the successor. Note that `GET /v1beta/models` is *not* a reliable check here - it kept listing `gemini-3-pro-preview` after the shutdown; only an actual `generateContent` call returns the 404
-- Claude Opus ($15/$75/MTok) is used for synthesis - monitor costs
-- Set reasoning to "Always disabled" if you want to use your selected model without upgrades
+- Claude Opus 4.5 ($5/$25/MTok) is used for synthesis - monitor costs
+- Setting reasoning to "Always disabled" reduces thinking-token use but does not change the configured synthesis model
 
 ## Configuring API Keys
 

--- a/src/components/StudySetup.tsx
+++ b/src/components/StudySetup.tsx
@@ -927,7 +927,7 @@ const StudySetup: React.FC = () => {
                 <option value="off">Always disabled</option>
               </select>
               <p className="text-xs text-stone-500">
-                Automatic: OFF for interviews (faster responses), ON for synthesis (deeper analysis using premium models - may increase API costs)
+                Automatic: OFF for interviews (faster responses), ON for synthesis (deeper analysis using the configured synthesis model - may increase API costs)
               </p>
             </div>
 

--- a/src/lib/providers/claude.ts
+++ b/src/lib/providers/claude.ts
@@ -243,7 +243,7 @@ export class ClaudeProvider implements AIProvider {
     try {
       const thinkingConfig = this.getSynthesisThinking(studyConfig.enableReasoning);
       const response = await this.client.messages.create({
-        model: CLAUDE_SYNTHESIS_MODEL,  // Auto-upgrade to best model for reasoning
+        model: CLAUDE_SYNTHESIS_MODEL,  // Use the configured higher-capability synthesis model
         max_tokens: thinkingConfig ? THINKING_BUDGET + 4096 : 2048,  // Increase for thinking
         ...(thinkingConfig && { thinking: thinkingConfig }),
         tools: [synthesisTool],
@@ -330,7 +330,7 @@ export class ClaudeProvider implements AIProvider {
     try {
       const thinkingConfig = this.getSynthesisThinking(studyConfig.enableReasoning);
       const response = await this.client.messages.create({
-        model: CLAUDE_SYNTHESIS_MODEL,  // Auto-upgrade to best model for reasoning
+        model: CLAUDE_SYNTHESIS_MODEL,  // Use the configured higher-capability synthesis model
         max_tokens: thinkingConfig ? THINKING_BUDGET + 8192 : 4096,  // Increase for thinking
         ...(thinkingConfig && { thinking: thinkingConfig }),
         tools: [aggregateTool],
@@ -402,7 +402,7 @@ Use the followup_study tool to provide your response.`;
     try {
       const thinkingConfig = this.getSynthesisThinking(parentConfig.enableReasoning);
       const response = await this.client.messages.create({
-        model: CLAUDE_SYNTHESIS_MODEL,  // Auto-upgrade to best model for reasoning
+        model: CLAUDE_SYNTHESIS_MODEL,  // Use the configured higher-capability synthesis model
         max_tokens: thinkingConfig ? THINKING_BUDGET + 2048 : 1024,  // Increase for thinking
         ...(thinkingConfig && { thinking: thinkingConfig }),
         tools: [followupTool],

--- a/src/lib/providers/gemini.ts
+++ b/src/lib/providers/gemini.ts
@@ -185,7 +185,7 @@ export class GeminiProvider implements AIProvider {
 
     try {
       const response = await this.ai.models.generateContent({
-        model: GEMINI_SYNTHESIS_MODEL,  // Auto-upgrade to best model for reasoning
+        model: GEMINI_SYNTHESIS_MODEL,  // Use the configured higher-capability synthesis model
         contents: prompt,
         config: {
           ...this.getSynthesisThinkingConfig(studyConfig.enableReasoning),
@@ -248,7 +248,7 @@ export class GeminiProvider implements AIProvider {
 
     try {
       const response = await this.ai.models.generateContent({
-        model: GEMINI_SYNTHESIS_MODEL,  // Auto-upgrade to best model for reasoning
+        model: GEMINI_SYNTHESIS_MODEL,  // Use the configured higher-capability synthesis model
         contents: prompt,
         config: {
           ...this.getSynthesisThinkingConfig(studyConfig.enableReasoning),
@@ -334,7 +334,7 @@ Return a JSON object with:
 
     try {
       const response = await this.ai.models.generateContent({
-        model: GEMINI_SYNTHESIS_MODEL,  // Auto-upgrade to best model for reasoning
+        model: GEMINI_SYNTHESIS_MODEL,  // Use the configured higher-capability synthesis model
         contents: prompt,
         config: {
           ...this.getSynthesisThinkingConfig(parentConfig.enableReasoning),

--- a/src/types.ts
+++ b/src/types.ts
@@ -68,21 +68,21 @@ export interface AIModelOption {
 export const GEMINI_MODELS: AIModelOption[] = [
   { id: 'gemini-2.5-flash', label: 'Gemini 2.5 Flash', desc: 'Fast, cost-effective' },
   { id: 'gemini-2.5-pro', label: 'Gemini 2.5 Pro', desc: 'Higher quality' },
-  { id: 'gemini-3.1-pro-preview', label: 'Gemini 3.1 Pro Preview', desc: 'Most intelligent (preview)' },
+  { id: 'gemini-3.1-pro-preview', label: 'Gemini 3.1 Pro Preview', desc: 'Higher capability (preview)' },
 ];
 
 // Available Claude models (verified from official docs)
 export const CLAUDE_MODELS: AIModelOption[] = [
   { id: 'claude-haiku-4-5', label: 'Claude Haiku 4.5', desc: 'Fastest ($1/$5 per MTok)' },
   { id: 'claude-sonnet-4-5', label: 'Claude Sonnet 4.5', desc: 'Balanced ($3/$15 per MTok)' },
-  { id: 'claude-opus-4-5', label: 'Claude Opus 4.5', desc: 'Most capable ($15/$75 per MTok)' },
+  { id: 'claude-opus-4-5', label: 'Claude Opus 4.5', desc: 'Higher capability ($5/$25 per MTok)' },
 ];
 
 // Default models for each provider
 export const DEFAULT_GEMINI_MODEL = 'gemini-2.5-flash';
 export const DEFAULT_CLAUDE_MODEL = 'claude-sonnet-4-5';
 
-// Synthesis models (auto-upgrade to best available for reasoning tasks)
+// Synthesis models (switch to the app's configured higher-capability model)
 export const GEMINI_SYNTHESIS_MODEL = 'gemini-3.1-pro-preview';
 export const CLAUDE_SYNTHESIS_MODEL = 'claude-opus-4-5';
 


### PR DESCRIPTION
## What changed

- correct Claude Opus 4.5 pricing from $15/$75 to $5/$25 per million tokens
- replace misleading auto-upgrade and premium/best-model language with the configured synthesis-model behavior
- remove obsolete superlatives from Gemini 3.1 Pro descriptions
- update the Anthropic documentation link

## Why

The pricing was stale, and the existing wording implied dynamic model selection that the code does not perform. Disabling reasoning changes thinking-token use, not the configured synthesis model.

## Impact

User-facing setup and study copy now matches the application behavior and current provider documentation. Model IDs, defaults, and runtime selection are unchanged.

## Validation

- `bun run build`
- production compilation, linting, type checking, and static generation completed successfully