### PR TITLE
Make the public demo tell the full research story

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,12 +18,13 @@ Open `/demo` on a running instance. No login, provider key, or database is requi
 
 The demo:
 
-- uses scripted sample responses and analysis;
+- lets visitors steer a fictional participant through three questions with fixed, branching responses;
+- ends in an illustrative researcher note with an exact transcript quote, interpretation, nuance, and hypothesis to test;
 - makes no AI-provider or persistence request;
-- keeps typed sample input in browser memory only and does not transmit or persist it; and
+- accepts no visitor-written interview content and keeps its selected path in component memory only; and
 - is safe to run while the real provider and storage configuration is absent.
 
-It is useful for evaluating the interaction, not model quality, latency, or provider availability.
+Every response, follow-up, and insight is pre-written and visibly labeled as synthetic. The demo is useful for understanding the participant-to-researcher workflow, not model quality, latency, or provider availability.
 
 ## 2. Use a hosted researcher account
 

--- a/src/app/demo/page.tsx
+++ b/src/app/demo/page.tsx
@@ -1,4 +1,11 @@
+import type { Metadata } from 'next';
 import DemoSimulation from '@/components/DemoSimulation';
+
+export const metadata: Metadata = {
+  title: 'Try a scripted interview | OpenInterviewer',
+  description:
+    'Follow a fictional participant through a deterministic qualitative interview, then inspect the evidence behind an illustrative researcher note.',
+};
 
 export default function DemoPage() {
   return <DemoSimulation />;

--- a/src/components/DemoSimulation.tsx
+++ b/src/components/DemoSimulation.tsx
@@ -1,131 +1,581 @@
 'use client';
 
-import React, { useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import Link from 'next/link';
-import { Bot, Send, User } from 'lucide-react';
+import {
+  ArrowRight,
+  BookOpen,
+  Bot,
+  Lightbulb,
+  Quote,
+  RotateCcw,
+  Search,
+  ShieldCheck,
+  Target,
+  User,
+} from 'lucide-react';
 
-const GREETING =
-  'This is a sample simulation of an AI interview. What would you like to notice about the conversation flow?';
-const FOLLOW_UP =
-  'In a live study the interviewer would follow that thread. This scripted sample stops here so you can see the shape of the exchange — nothing was stored or sent to a model.';
+type DemoPath = 'project' | 'recommendation' | 'curiosity';
+type DemoView = 'intro' | 'interview' | 'insight';
+
+interface DemoChoice {
+  id: string;
+  text: string;
+  path?: DemoPath;
+}
+
+interface DemoBranch {
+  label: string;
+  followUp: string;
+  secondChoices: DemoChoice[];
+  deepProbe: string;
+  thirdChoices: DemoChoice[];
+  theme: string;
+  bottomLine: string;
+  interpretation: string;
+  hypothesis: string;
+  nuance: string;
+}
+
+interface TranscriptMessage {
+  id: string;
+  role: 'interviewer' | 'participant';
+  content: string;
+  evidence?: boolean;
+}
+
+const STUDY_NAME = 'Reading lists people actually return to';
+const RESEARCH_QUESTION = 'Why do people save articles they intend to read but rarely revisit?';
+const OPENING_QUESTION =
+  'Think about the last article you saved but did not finish. What made you save it?';
+const CLOSING_MESSAGE =
+  'That distinction is useful. In a real study, the researcher would compare this account with other interviews. Let us switch views and inspect the note this fictional path produces.';
+
+const FIRST_CHOICES: DemoChoice[] = [
+  {
+    id: 'project',
+    path: 'project',
+    text: 'It looked useful for a work project, but I did not have time then.',
+  },
+  {
+    id: 'recommendation',
+    path: 'recommendation',
+    text: 'A colleague I trust said it changed how they thought about the topic.',
+  },
+  {
+    id: 'curiosity',
+    path: 'curiosity',
+    text: 'The headline made me curious, but I was not ready to give it twenty minutes.',
+  },
+];
+
+const BRANCHES: Record<DemoPath, DemoBranch> = {
+  project: {
+    label: 'Project context',
+    followUp:
+      'You saved it for a specific future use. When you came back, what got in the way?',
+    secondChoices: [
+      {
+        id: 'project-context-lost',
+        text: 'I had forgotten which project it was for, so opening it felt like work before the reading even started.',
+      },
+      {
+        id: 'project-moved-on',
+        text: 'I could not remember why I had saved it, and by then the project had moved on, so it felt obsolete.',
+      },
+    ],
+    deepProbe:
+      'The reason for saving had faded. If the tool could preserve one thing from that moment, what would help most?',
+    thirdChoices: [
+      {
+        id: 'project-own-note',
+        text: 'A one-line note in my own words: why it mattered and what I hoped to use it for.',
+      },
+      {
+        id: 'project-question',
+        text: 'The project name and the question I was trying to answer when I saved it.',
+      },
+    ],
+    theme: 'Lost context creates re-entry work',
+    bottomLine:
+      'Returning fails when the reason for saving is lost; preserving intent may matter more than sending another reminder.',
+    interpretation:
+      'Reconstructing purpose becomes part of the cost of reading, so the saved item feels like unfinished administrative work.',
+    hypothesis:
+      'Capture a short statement of intended use at save time, then restore it when the reader chooses to return.',
+    nuance:
+      'The participant is not asking the product to create urgency. They want context available at the moment of re-entry.',
+  },
+  recommendation: {
+    label: 'Borrowed relevance',
+    followUp:
+      'The recommendation carried someone else’s judgment. What changed when you returned without them there?',
+    secondChoices: [
+      {
+        id: 'recommendation-why',
+        text: 'I remembered that they valued it, but not why they thought it mattered to me.',
+      },
+      {
+        id: 'recommendation-obligation',
+        text: 'I could not remember why they thought it fit me, so it felt like an obligation rather than my own choice.',
+      },
+    ],
+    deepProbe:
+      'The social reason stayed, but the personal reason weakened. What would help you decide whether it still deserves attention?',
+    thirdChoices: [
+      {
+        id: 'recommendation-specific-note',
+        text: 'A note from them about the specific idea they wanted me to notice.',
+      },
+      {
+        id: 'recommendation-dismiss',
+        text: 'A quick way to say “not for me” without leaving it in the queue forever.',
+      },
+    ],
+    theme: 'Borrowed relevance decays without a reason',
+    bottomLine:
+      'A trusted recommendation gets an article saved, but not necessarily read; the missing ingredient is why it mattered to this reader.',
+    interpretation:
+      'Social trust creates initial relevance, while an unexplained recommendation can later feel like an obligation rather than a choice.',
+    hypothesis:
+      'Preserve the recommender’s rationale and offer a graceful way to dismiss items that no longer feel personally relevant.',
+    nuance:
+      'The participant values the colleague’s judgment but resists turning that relationship into a permanent reading debt.',
+  },
+  curiosity: {
+    label: 'Fading curiosity',
+    followUp:
+      'Curiosity was enough to save it, but not enough to read it. What happened when you saw it again?',
+    secondChoices: [
+      {
+        id: 'curiosity-moment-passed',
+        text: 'I could not remember the question that made the headline interesting once the original moment had passed.',
+      },
+      {
+        id: 'curiosity-crowded-list',
+        text: 'I had dozens of saved pieces, and nothing told me why this one had mattered.',
+      },
+    ],
+    deepProbe:
+      'The list kept the article but not the question behind it. What would make resurfacing feel useful instead of like backlog?',
+    thirdChoices: [
+      {
+        id: 'curiosity-original-question',
+        text: 'Show me the question I had when I saved it, not just the title.',
+      },
+      {
+        id: 'curiosity-expire',
+        text: 'Let older items quietly expire instead of asking me to clear them one by one.',
+      },
+    ],
+    theme: 'Saved curiosity becomes undifferentiated backlog',
+    bottomLine:
+      'A reading list preserves the object but loses the question that made it interesting, so curiosity turns into maintenance.',
+    interpretation:
+      'The participant does not need more resurfacing; they need the original spark restored or permission for the item to disappear.',
+    hypothesis:
+      'Save the reader’s question alongside the article and allow low-intent items to decay without demanding inbox-style cleanup.',
+    nuance:
+      'More reminders could increase guilt while doing nothing to recover the curiosity that prompted the save.',
+  },
+};
+
+function buildTranscript(answers: string[], path: DemoPath | null): TranscriptMessage[] {
+  const messages: TranscriptMessage[] = [
+    {
+      id: 'opening',
+      role: 'interviewer',
+      content: OPENING_QUESTION,
+    },
+  ];
+
+  if (!path) return messages;
+
+  const branch = BRANCHES[path];
+  const interviewerReplies = [branch.followUp, branch.deepProbe, CLOSING_MESSAGE];
+
+  answers.forEach((answer, index) => {
+    messages.push({
+      id: `participant-${index + 1}`,
+      role: 'participant',
+      content: answer,
+      evidence: index === 1,
+    });
+    messages.push({
+      id: `interviewer-${index + 2}`,
+      role: 'interviewer',
+      content: interviewerReplies[index],
+    });
+  });
+
+  return messages;
+}
 
 const DemoSimulation: React.FC = () => {
-  const [started, setStarted] = useState(false);
-  const [input, setInput] = useState('');
-  const [userMessage, setUserMessage] = useState<string | null>(null);
-  const [replied, setReplied] = useState(false);
+  const [view, setView] = useState<DemoView>('intro');
+  const [path, setPath] = useState<DemoPath | null>(null);
+  const [answers, setAnswers] = useState<string[]>([]);
+  const [highlightEvidence, setHighlightEvidence] = useState(false);
+  const [hasSeenInsight, setHasSeenInsight] = useState(false);
+  const choiceGroupRef = useRef<HTMLFieldSetElement>(null);
+  const completionButtonRef = useRef<HTMLButtonElement>(null);
+  const insightHeadingRef = useRef<HTMLHeadingElement>(null);
+  const evidenceRef = useRef<HTMLLIElement>(null);
 
-  const handleSend = () => {
-    const text = input.trim();
-    if (!text || !started || replied) {
-      if (replied) setInput('');
+  const branch = path ? BRANCHES[path] : null;
+  const transcript = buildTranscript(answers, path);
+  const interviewComplete = answers.length === 3;
+
+  let choices: DemoChoice[] = FIRST_CHOICES;
+  if (branch && answers.length === 1) choices = branch.secondChoices;
+  if (branch && answers.length === 2) choices = branch.thirdChoices;
+  if (interviewComplete) choices = [];
+
+  useEffect(() => {
+    if (view === 'insight') {
+      insightHeadingRef.current?.focus();
       return;
     }
-    setUserMessage(text);
-    setInput('');
-    setReplied(true);
+    if (view === 'interview' && highlightEvidence) {
+      evidenceRef.current?.focus();
+      return;
+    }
+    if (view === 'interview' && interviewComplete) {
+      completionButtonRef.current?.focus();
+      return;
+    }
+    if (view === 'interview' && !interviewComplete) {
+      choiceGroupRef.current?.focus();
+    }
+  }, [answers.length, highlightEvidence, interviewComplete, view]);
+
+  const resetTo = (nextView: DemoView) => {
+    setPath(null);
+    setAnswers([]);
+    setHighlightEvidence(false);
+    setHasSeenInsight(false);
+    setView(nextView);
+  };
+
+  const handleChoice = (choice: DemoChoice) => {
+    if (answers.length === 0) {
+      if (!choice.path) return;
+      setPath(choice.path);
+    }
+    setHighlightEvidence(false);
+    setAnswers((current) => [...current, choice.text]);
+  };
+
+  const showInsight = () => {
+    setHasSeenInsight(true);
+    setHighlightEvidence(false);
+    setView('insight');
+  };
+
+  const traceEvidence = () => {
+    setHighlightEvidence(true);
+    setView('interview');
   };
 
   return (
-    <div className="min-h-screen bg-stone-900 flex flex-col">
-      <div className="border-b border-amber-700/40 bg-amber-950/40 px-6 py-4">
-        <p className="text-amber-100 font-medium">
-          This is a sample simulation. It does not use live AI and does not store anything.
-        </p>
-        <p className="text-amber-200/80 text-sm mt-1">
-          Do not enter personal or confidential information.
-        </p>
-        <div className="mt-3 flex flex-wrap gap-4 text-sm">
-          <Link href="/login" className="text-amber-100 underline underline-offset-2 hover:text-white">
-            Researcher sign in
-          </Link>
-          <Link href="/login?redirect=/setup" className="text-amber-100 underline underline-offset-2 hover:text-white">
-            Set up a real study
-          </Link>
-        </div>
-      </div>
-
-      <div className="flex-1 flex flex-col max-w-3xl w-full mx-auto px-6 py-8">
-        {!started ? (
-          <div className="flex-1 flex flex-col items-center justify-center text-center space-y-6">
-            <h1 className="text-3xl font-bold text-white">Try a sample interview</h1>
-            <p className="text-stone-400 max-w-md">
-              A short, keyless walkthrough of the interview UI. Scripted replies only — no provider, no network, no persistence.
-            </p>
-            <button
-              type="button"
-              data-testid="demo-start"
-              onClick={() => setStarted(true)}
-              className="px-6 py-3 bg-stone-600 hover:bg-stone-500 text-white font-medium rounded-xl transition-colors"
-            >
-              Start sample
-            </button>
+    <div className="min-h-dvh bg-stone-900 text-stone-100">
+      <aside
+        aria-label="Demo disclosure"
+        className="border-b border-amber-700/40 bg-amber-950/40"
+      >
+        <div className="mx-auto flex max-w-5xl flex-col gap-3 px-4 py-4 sm:px-6 lg:flex-row lg:items-center lg:justify-between">
+          <div className="flex items-start gap-3">
+            <ShieldCheck aria-hidden="true" className="mt-0.5 shrink-0 text-amber-200" size={20} />
+            <div>
+              <p className="font-semibold text-amber-100">Scripted demo</p>
+              <p className="text-sm text-amber-100/85">
+                Maya is fictional. Every response, follow-up, and insight is pre-written. No demo response leaves this page or survives a refresh.
+              </p>
+            </div>
           </div>
-        ) : (
-          <>
-            <div className="flex-1 space-y-4 pb-6">
-              <div data-testid="demo-message-ai" className="flex justify-start">
-                <div className="max-w-[80%] rounded-2xl rounded-bl-md p-4 bg-stone-800 border border-stone-700 text-stone-100">
-                  <div className="flex items-center gap-2 mb-2 text-xs text-stone-500">
-                    <Bot size={14} />
-                    Sample interviewer
-                  </div>
-                  <p>{GREETING}</p>
-                </div>
+          <nav aria-label="Demo links" className="flex flex-wrap gap-x-4 gap-y-2 text-sm">
+            <Link href="/login" className="text-amber-100 underline underline-offset-4 hover:text-white">
+              Configured workspace
+            </Link>
+            <Link href="/self-host" className="text-amber-100 underline underline-offset-4 hover:text-white">
+              Self-host setup
+            </Link>
+          </nav>
+        </div>
+      </aside>
+
+      <main className="mx-auto w-full max-w-5xl px-4 py-8 sm:px-6 sm:py-12">
+        {view === 'intro' && (
+          <div className="space-y-8">
+            <div className="grid items-start gap-8 lg:grid-cols-[1.15fr_0.85fr]">
+              <div className="space-y-5">
+                <p className="text-sm font-semibold uppercase tracking-[0.18em] text-stone-400">
+                  Participant view → researcher view
+                </p>
+                <h1 className="text-4xl font-bold tracking-tight text-white sm:text-5xl">
+                  See an interview become an insight.
+                </h1>
+                <p className="max-w-2xl text-lg leading-8 text-stone-300">
+                  Choose Maya’s fictional replies in a two-minute walkthrough. Watch the interviewer follow her thread, then inspect the evidence behind the researcher note.
+                </p>
+                <button
+                  type="button"
+                  data-testid="demo-start"
+                  onClick={() => setView('interview')}
+                  className="inline-flex min-h-11 items-center justify-center gap-2 rounded-xl bg-stone-100 px-5 py-3 font-semibold text-stone-900 transition-colors hover:bg-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-300 focus-visible:ring-offset-2 focus-visible:ring-offset-stone-900"
+                >
+                  Begin scripted interview
+                  <ArrowRight aria-hidden="true" size={18} />
+                </button>
               </div>
 
-              {userMessage && (
-                <div className="flex justify-end">
-                  <div className="max-w-[80%] rounded-2xl rounded-br-md p-4 bg-stone-700 text-white">
-                    <div className="flex items-center gap-2 mb-2 text-xs text-stone-400 justify-end">
-                      You
-                      <User size={14} />
-                    </div>
-                    <p>{userMessage}</p>
-                  </div>
+              <section aria-labelledby="demo-study-heading" className="rounded-2xl border border-stone-700 bg-stone-800/70 p-5 sm:p-6">
+                <div className="mb-4 flex items-center gap-2 text-stone-300">
+                  <BookOpen aria-hidden="true" size={18} />
+                  <span className="text-xs font-semibold uppercase tracking-[0.16em]">Synthetic study</span>
                 </div>
-              )}
-
-              {replied && (
-                <div data-testid="demo-message-ai" className="flex justify-start">
-                  <div className="max-w-[80%] rounded-2xl rounded-bl-md p-4 bg-stone-800 border border-stone-700 text-stone-100">
-                    <div className="flex items-center gap-2 mb-2 text-xs text-stone-500">
-                      <Bot size={14} />
-                      Sample interviewer
-                    </div>
-                    <p>{FOLLOW_UP}</p>
-                  </div>
-                </div>
-              )}
+                <h2 id="demo-study-heading" className="text-xl font-semibold text-white">{STUDY_NAME}</h2>
+                <p className="mt-4 text-xs font-semibold uppercase tracking-[0.14em] text-stone-400">Research question</p>
+                <p className="mt-2 leading-7 text-stone-200">{RESEARCH_QUESTION}</p>
+              </section>
             </div>
 
-            <div className="flex gap-3 pb-4">
-              <label htmlFor="demo-chat-input" className="sr-only">
-                Sample response
-              </label>
-              <input
-                id="demo-chat-input"
-                type="text"
-                data-testid="demo-chat-input"
-                value={input}
-                onChange={(e) => setInput(e.target.value)}
-                onKeyDown={(e) => e.key === 'Enter' && handleSend()}
-                placeholder="Type a sample response..."
-                className="flex-1 px-4 py-3 bg-stone-800 border border-stone-600 text-stone-100 placeholder-stone-500 rounded-xl focus:outline-none focus:ring-2 focus:ring-stone-500"
-              />
+            <ol aria-label="Demo workflow" className="grid gap-3 sm:grid-cols-3">
+              {[
+                ['1', 'Recall a moment', 'Begin with a concrete experience, not an abstract opinion.'],
+                ['2', 'Follow the thread', 'Probe what the participant means instead of reading the next fixed question.'],
+                ['3', 'Trace the insight', 'Keep interpretation beside the exact transcript evidence that supports it.'],
+              ].map(([number, title, description]) => (
+                <li key={number} className="rounded-2xl border border-stone-800 bg-stone-850 p-5">
+                  <span className="text-sm font-semibold text-amber-200">{number}</span>
+                  <h3 className="mt-2 font-semibold text-white">{title}</h3>
+                  <p className="mt-2 text-sm leading-6 text-stone-400">{description}</p>
+                </li>
+              ))}
+            </ol>
+          </div>
+        )}
+
+        {view === 'interview' && (
+          <div className="space-y-6">
+            <header className="space-y-3">
+              <div className="flex flex-wrap items-center justify-between gap-3">
+                <p className="text-sm font-semibold uppercase tracking-[0.16em] text-stone-400">Synthetic study</p>
+                <button
+                  type="button"
+                  onClick={() => resetTo('intro')}
+                  className="text-sm text-stone-300 underline underline-offset-4 hover:text-white"
+                >
+                  Back to overview
+                </button>
+              </div>
+              <h1 className="text-3xl font-bold text-white sm:text-4xl">{STUDY_NAME}</h1>
+              <p className="max-w-3xl text-stone-300">
+                <span className="font-medium text-stone-100">Research question:</span> {RESEARCH_QUESTION}
+              </p>
+            </header>
+
+            <div
+              role="status"
+              data-testid="demo-progress"
+              className="flex flex-wrap items-center justify-between gap-3 rounded-xl border border-stone-700 bg-stone-800/60 px-4 py-3 text-sm"
+            >
+              <span className="font-medium text-stone-200">
+                {interviewComplete ? 'Interview complete' : `Question ${answers.length + 1} of 3`}
+              </span>
+              <span className="text-stone-400">
+                {branch ? `Scripted branch: ${branch.label}` : 'Choose the opening path'}
+              </span>
+            </div>
+
+            <section aria-labelledby="transcript-heading" className="rounded-2xl border border-stone-700 bg-stone-850 p-4 sm:p-6">
+              <h2 id="transcript-heading" className="sr-only">Scripted interview transcript</h2>
+              <div role="log" aria-live="polite" aria-relevant="additions">
+                <ol className="space-y-4">
+                  {transcript.map((message) => (
+                  <li
+                    key={message.id}
+                    ref={message.evidence ? evidenceRef : undefined}
+                    tabIndex={message.evidence ? -1 : undefined}
+                    data-testid={message.evidence ? 'demo-evidence-turn' : message.role === 'interviewer' ? 'demo-message-ai' : undefined}
+                    className={`flex ${message.role === 'participant' ? 'justify-end' : 'justify-start'} rounded-xl focus:outline-none ${
+                      message.evidence && highlightEvidence ? 'ring-2 ring-amber-300 ring-offset-4 ring-offset-stone-900' : ''
+                    }`}
+                  >
+                    <div
+                      className={`max-w-[92%] rounded-2xl p-4 sm:max-w-[78%] ${
+                        message.role === 'participant'
+                          ? 'rounded-br-md bg-stone-700 text-white'
+                          : 'rounded-bl-md border border-stone-700 bg-stone-800 text-stone-100'
+                      }`}
+                    >
+                      <div className={`mb-2 flex items-center gap-2 text-xs font-medium ${message.role === 'participant' ? 'justify-end text-stone-200' : 'text-stone-400'}`}>
+                        {message.role === 'interviewer' ? (
+                          <>
+                            <Bot aria-hidden="true" size={14} />
+                            Scripted interviewer
+                          </>
+                        ) : (
+                          <>
+                            Maya · fictional participant
+                            <User aria-hidden="true" size={14} />
+                          </>
+                        )}
+                      </div>
+                      <p className="leading-7">{message.content}</p>
+                    </div>
+                    </li>
+                  ))}
+                </ol>
+              </div>
+
+              {!interviewComplete && (
+                <fieldset
+                  ref={choiceGroupRef}
+                  tabIndex={-1}
+                  className="mt-6 border-t border-stone-700 pt-5 focus:outline-none"
+                >
+                  <legend className="px-1 text-base font-semibold text-white">Choose Maya’s response</legend>
+                  <p className="mb-3 mt-1 text-sm text-stone-400">Every option is fictional and pre-written.</p>
+                  <div className="grid gap-3">
+                    {choices.map((choice) => (
+                      <button
+                        key={choice.id}
+                        type="button"
+                        data-testid={`demo-choice-${choice.id}`}
+                        onClick={() => handleChoice(choice)}
+                        className="min-h-11 w-full rounded-xl border border-stone-600 bg-stone-800 px-4 py-3 text-left leading-6 text-stone-100 transition-colors hover:border-stone-400 hover:bg-stone-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-300 focus-visible:ring-offset-2 focus-visible:ring-offset-stone-850"
+                      >
+                        {choice.text}
+                      </button>
+                    ))}
+                  </div>
+                </fieldset>
+              )}
+
+              {interviewComplete && (
+                <div className="mt-6 border-t border-stone-700 pt-5">
+                  <button
+                    ref={completionButtonRef}
+                    type="button"
+                    data-testid="demo-view-insight"
+                    onClick={showInsight}
+                    className="inline-flex min-h-11 w-full items-center justify-center gap-2 rounded-xl bg-stone-100 px-5 py-3 font-semibold text-stone-900 transition-colors hover:bg-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-300 focus-visible:ring-offset-2 focus-visible:ring-offset-stone-900 sm:w-auto"
+                  >
+                    {hasSeenInsight ? 'Return to researcher note' : 'See researcher view'}
+                    <ArrowRight aria-hidden="true" size={18} />
+                  </button>
+                </div>
+              )}
+            </section>
+          </div>
+        )}
+
+        {view === 'insight' && branch && (
+          <div data-testid="demo-insight" className="space-y-6">
+            <header className="space-y-3">
+              <p className="text-sm font-semibold uppercase tracking-[0.16em] text-stone-400">Researcher view</p>
+              <h1 ref={insightHeadingRef} tabIndex={-1} className="text-3xl font-bold text-white outline-none sm:text-4xl">
+                Illustrative synthesis
+              </h1>
+              <p className="max-w-3xl text-lg text-stone-300">
+                Based on one fictional interview. This is an interpretation, not a research finding.
+              </p>
+            </header>
+
+            <div
+              data-testid="demo-insight-disclosure"
+              className="flex items-start gap-3 rounded-xl border border-amber-700/50 bg-amber-950/30 p-4 text-sm text-amber-100"
+            >
+              <ShieldCheck aria-hidden="true" className="mt-0.5 shrink-0" size={18} />
+              <p>
+                This note was authored in advance for the <strong>{branch.label}</strong> path. No model analyzed Maya or generated these claims.
+              </p>
+            </div>
+
+            <section aria-labelledby="bottom-line-heading" className="rounded-2xl bg-stone-700 p-5 text-white sm:p-6">
+              <div className="mb-3 flex items-center gap-2 text-stone-200">
+                <Target aria-hidden="true" size={18} />
+                <h2 id="bottom-line-heading" className="text-sm font-semibold uppercase tracking-[0.14em]">Bottom line</h2>
+              </div>
+              <p className="text-xl font-medium leading-8 sm:text-2xl">{branch.bottomLine}</p>
+            </section>
+
+            <div className="grid gap-6 lg:grid-cols-[1.25fr_0.75fr]">
+              <section aria-labelledby="evidence-heading" className="rounded-2xl border border-stone-700 bg-stone-800/70 p-5 sm:p-6">
+                <div className="mb-5 flex items-center gap-2">
+                  <Search aria-hidden="true" className="text-stone-400" size={18} />
+                  <h2 id="evidence-heading" className="font-semibold text-white">Evidence trail</h2>
+                </div>
+                <dl className="space-y-5">
+                  <div>
+                    <dt className="text-xs font-semibold uppercase tracking-[0.14em] text-stone-400">Emerging theme</dt>
+                    <dd className="mt-2 font-medium text-stone-100">{branch.theme}</dd>
+                  </div>
+                  <div>
+                    <dt className="flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.14em] text-stone-400">
+                      <Quote aria-hidden="true" size={14} /> Evidence quote
+                    </dt>
+                    <dd className="mt-2 border-l-2 border-amber-300 pl-4 leading-7 text-stone-200">“{answers[1]}”</dd>
+                    <dd className="mt-2 text-xs text-stone-400">Maya · participant response · turn 4</dd>
+                  </div>
+                  <div>
+                    <dt className="text-xs font-semibold uppercase tracking-[0.14em] text-stone-400">Interpretation</dt>
+                    <dd className="mt-2 leading-7 text-stone-200">{branch.interpretation}</dd>
+                  </div>
+                </dl>
+              </section>
+
+              <div className="space-y-4">
+                <section aria-labelledby="hypothesis-heading" className="rounded-2xl border border-stone-700 bg-stone-800/70 p-5">
+                  <div className="mb-3 flex items-center gap-2">
+                    <Lightbulb aria-hidden="true" className="text-stone-400" size={18} />
+                    <h2 id="hypothesis-heading" className="font-semibold text-white">Hypothesis to test</h2>
+                  </div>
+                  <p className="text-sm leading-6 text-stone-300">{branch.hypothesis}</p>
+                </section>
+                <section aria-labelledby="nuance-heading" className="rounded-2xl border border-stone-700 bg-stone-850 p-5">
+                  <h2 id="nuance-heading" className="font-semibold text-white">Nuance worth preserving</h2>
+                  <p className="mt-2 text-sm leading-6 text-stone-300">{branch.nuance}</p>
+                </section>
+              </div>
+            </div>
+
+            <section aria-labelledby="real-product-heading" className="rounded-2xl border border-stone-700 bg-stone-850 p-5 sm:p-6">
+              <h2 id="real-product-heading" className="font-semibold text-white">What changes in a real study?</h2>
+              <p className="mt-2 max-w-3xl text-sm leading-6 text-stone-300">
+                A configured AI interviewer generates follow-ups from each participant’s words. Researchers then synthesize across interviews while retaining transcripts and evidence provenance. This demo replaces both steps with fixed branches and a pre-written note.
+              </p>
+            </section>
+
+            <div className="flex flex-col gap-3 sm:flex-row sm:flex-wrap">
               <button
                 type="button"
-                aria-label="Send sample response"
-                onClick={handleSend}
-                disabled={!input.trim()}
-                className="p-3 bg-stone-600 hover:bg-stone-500 text-white rounded-xl disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+                onClick={traceEvidence}
+                className="inline-flex min-h-11 items-center justify-center gap-2 rounded-xl border border-stone-600 px-5 py-3 font-semibold text-stone-100 hover:bg-stone-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-300"
               >
-                <Send size={20} />
+                <Quote aria-hidden="true" size={18} />
+                Trace this insight in the transcript
               </button>
+              <button
+                type="button"
+                onClick={() => resetTo('interview')}
+                className="inline-flex min-h-11 items-center justify-center gap-2 rounded-xl border border-stone-600 px-5 py-3 font-semibold text-stone-100 hover:bg-stone-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-300"
+              >
+                <RotateCcw aria-hidden="true" size={18} />
+                Replay another path
+              </button>
+              <Link
+                href="/self-host"
+                className="inline-flex min-h-11 items-center justify-center gap-2 rounded-xl bg-stone-100 px-5 py-3 font-semibold text-stone-900 hover:bg-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-300"
+              >
+                Set up your own instance
+                <ArrowRight aria-hidden="true" size={18} />
+              </Link>
             </div>
-          </>
+          </div>
         )}
-      </div>
+      </main>
     </div>
   );
 };

--- a/src/components/Landing.tsx
+++ b/src/components/Landing.tsx
@@ -1,79 +1,129 @@
 'use client';
 
 import Link from 'next/link';
-import { motion } from 'framer-motion';
-import { Beaker, LogIn, Server } from 'lucide-react';
+import { ArrowRight, Beaker, BookOpen, GitBranch, LogIn, Quote, Server } from 'lucide-react';
 
 const Landing: React.FC = () => {
   return (
-    <div className="min-h-screen bg-stone-900 flex items-center justify-center p-8">
-      <motion.div
-        initial={{ opacity: 0, y: 16 }}
-        animate={{ opacity: 1, y: 0 }}
-        className="max-w-2xl w-full space-y-10"
-      >
-        <div className="space-y-3">
-          <p className="text-sm uppercase tracking-wide text-stone-400">OpenInterviewer</p>
-          <h1 className="text-4xl font-bold text-white">AI interviews for qualitative research</h1>
-          <p className="text-stone-400 text-lg">
-            Try a scripted sample first, or sign in to run real studies. The sample never stores data and does not use live AI.
-          </p>
-        </div>
+    <main className="min-h-dvh bg-stone-900 px-4 py-10 text-stone-100 sm:px-8 sm:py-16">
+      <div className="mx-auto max-w-5xl space-y-14">
+        <section aria-labelledby="landing-heading" className="grid items-end gap-8 lg:grid-cols-[1.2fr_0.8fr]">
+          <div className="space-y-6">
+            <p className="text-sm font-semibold uppercase tracking-[0.18em] text-stone-400">
+              OpenInterviewer · Open source
+            </p>
+            <h1 id="landing-heading" className="max-w-3xl text-4xl font-bold tracking-tight text-white sm:text-6xl sm:leading-[1.05]">
+              Follow the answer, not just the script.
+            </h1>
+            <p className="max-w-2xl text-lg leading-8 text-stone-300 sm:text-xl">
+              Turn a research guide into an adaptive interview. Participants get thoughtful follow-ups; researchers get interpretations linked back to transcript evidence.
+            </p>
+            <div className="flex flex-col gap-3 sm:flex-row sm:flex-wrap">
+              <Link
+                href="/demo"
+                className="inline-flex min-h-12 items-center justify-center gap-2 rounded-xl bg-stone-100 px-5 py-3 font-semibold text-stone-900 transition-colors hover:bg-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-300 focus-visible:ring-offset-2 focus-visible:ring-offset-stone-900"
+              >
+                Try the scripted demo · 2 min
+                <ArrowRight aria-hidden="true" size={18} />
+              </Link>
+              <Link
+                href="/self-host"
+                className="inline-flex min-h-12 items-center justify-center gap-2 rounded-xl border border-stone-600 px-5 py-3 font-semibold text-stone-100 transition-colors hover:bg-stone-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-300"
+              >
+                <Server aria-hidden="true" size={18} />
+                Self-host your own
+              </Link>
+            </div>
+          </div>
 
-        <div className="grid gap-4">
-          <Link
-            href="/demo"
-            className="block rounded-2xl border border-stone-700 bg-stone-800/60 p-6 hover:border-stone-500 hover:bg-stone-800 transition-colors"
-          >
-            <div className="flex items-start gap-4">
-              <div className="w-10 h-10 rounded-xl bg-stone-700 flex items-center justify-center shrink-0">
-                <Beaker size={20} className="text-stone-300" />
-              </div>
+          <div className="rounded-2xl border border-amber-700/40 bg-amber-950/30 p-5">
+            <div className="flex items-start gap-3">
+              <Beaker aria-hidden="true" className="mt-0.5 shrink-0 text-amber-200" size={20} />
               <div>
-                <h2 className="text-lg font-semibold text-white">Try a sample</h2>
-                <p className="text-sm text-stone-400 mt-1">
-                  Keyless, scripted walkthrough. No account, no API keys, no saved responses, and no live model.
+                <h2 className="font-semibold text-amber-100">Safe to try immediately</h2>
+                <p className="mt-2 text-sm leading-6 text-amber-100/80">
+                  Fictional participant, fixed branches, no account, API key, live AI, interview API call, or saved data.
                 </p>
               </div>
             </div>
-          </Link>
+          </div>
+        </section>
 
+        <section aria-labelledby="workflow-heading" className="space-y-5">
+          <div>
+            <p className="text-sm font-semibold uppercase tracking-[0.16em] text-stone-400">The research loop</p>
+            <h2 id="workflow-heading" className="mt-2 text-2xl font-semibold text-white sm:text-3xl">
+              From a question to evidence you can inspect.
+            </h2>
+          </div>
+          <ol className="grid gap-4 md:grid-cols-3">
+            {[
+              {
+                icon: BookOpen,
+                step: '01',
+                title: 'Frame the study',
+                description: 'Define a research question, topic guide, and the context you need from participants.',
+              },
+              {
+                icon: GitBranch,
+                step: '02',
+                title: 'Follow the thread',
+                description: 'Probe what a participant means instead of mechanically asking the next prepared question.',
+              },
+              {
+                icon: Quote,
+                step: '03',
+                title: 'Trace the insight',
+                description: 'Review interpretations, nuances, and hypotheses alongside their transcript evidence.',
+              },
+            ].map(({ icon: Icon, step, title, description }) => (
+              <li key={step} className="rounded-2xl border border-stone-700 bg-stone-800/60 p-5 sm:p-6">
+                <div className="flex items-center justify-between">
+                  <Icon aria-hidden="true" className="text-stone-300" size={21} />
+                  <span className="text-xs font-semibold tracking-[0.16em] text-stone-400">{step}</span>
+                </div>
+                <h3 className="mt-6 text-lg font-semibold text-white">{title}</h3>
+                <p className="mt-2 text-sm leading-6 text-stone-400">{description}</p>
+              </li>
+            ))}
+          </ol>
+        </section>
+
+        <section aria-label="Ways to run OpenInterviewer" className="grid gap-4 border-t border-stone-800 pt-8 sm:grid-cols-2">
           <Link
             href="/login"
-            className="block rounded-2xl border border-stone-700 bg-stone-800/40 p-6 hover:border-stone-500 hover:bg-stone-800 transition-colors"
+            className="group rounded-2xl border border-stone-800 p-5 transition-colors hover:border-stone-600 hover:bg-stone-850"
           >
-            <div className="flex items-start gap-4">
-              <div className="w-10 h-10 rounded-xl bg-stone-700 flex items-center justify-center shrink-0">
-                <LogIn size={20} className="text-stone-300" />
-              </div>
-              <div>
-                <h2 className="text-lg font-semibold text-white">Researcher workspace</h2>
-                <p className="text-sm text-stone-400 mt-1">
-                  Sign in to create studies, generate participant links, and review interviews.
-                </p>
-              </div>
+            <div className="flex items-center gap-3">
+              <LogIn aria-hidden="true" className="text-stone-400" size={19} />
+              <h2 className="font-semibold text-white">Configured researcher workspace</h2>
             </div>
+            <p className="mt-2 text-sm leading-6 text-stone-400">
+              Sign in to a deployment that already has working storage and provider access.
+            </p>
+            <span className="mt-4 inline-flex items-center gap-2 text-sm font-medium text-stone-200 group-hover:text-white">
+              Researcher sign in <ArrowRight aria-hidden="true" size={16} />
+            </span>
           </Link>
 
           <Link
             href="/self-host"
-            className="block rounded-2xl border border-stone-700 bg-stone-800/40 p-6 hover:border-stone-500 hover:bg-stone-800 transition-colors"
+            className="group rounded-2xl border border-stone-800 p-5 transition-colors hover:border-stone-600 hover:bg-stone-850"
           >
-            <div className="flex items-start gap-4">
-              <div className="w-10 h-10 rounded-xl bg-stone-700 flex items-center justify-center shrink-0">
-                <Server size={20} className="text-stone-300" />
-              </div>
-              <div>
-                <h2 className="text-lg font-semibold text-white">Self-host</h2>
-                <p className="text-sm text-stone-400 mt-1">
-                  Deploy your own instance with your API keys and storage. Open source, MIT licensed.
-                </p>
-              </div>
+            <div className="flex items-center gap-3">
+              <Server aria-hidden="true" className="text-stone-400" size={19} />
+              <h2 className="font-semibold text-white">Self-host</h2>
             </div>
+            <p className="mt-2 text-sm leading-6 text-stone-400">
+              Deploy the MIT-licensed application with your own provider keys and Upstash database.
+            </p>
+            <span className="mt-4 inline-flex items-center gap-2 text-sm font-medium text-stone-200 group-hover:text-white">
+              View deployment guide <ArrowRight aria-hidden="true" size={16} />
+            </span>
           </Link>
-        </div>
-      </motion.div>
-    </div>
+        </section>
+      </div>
+    </main>
   );
 };
 

--- a/tests/e2e/demo-no-provider.spec.ts
+++ b/tests/e2e/demo-no-provider.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test } from '@playwright/test';
 
-test('public demo is deterministic and makes no API requests', async ({ page }) => {
+test('public demo closes the research loop without API or external requests', async ({ page }) => {
   const appOrigin = `http://127.0.0.1:${process.env.PLAYWRIGHT_PORT || '3100'}`;
   const apiRequests: string[] = [];
   const externalRequests: string[] = [];
@@ -16,17 +16,31 @@ test('public demo is deterministic and makes no API requests', async ({ page }) 
 
   await page.goto('/demo');
 
-  await expect(page.getByText(/sample simulation/i)).toBeVisible();
-  await expect(page.getByText(/do not enter personal or confidential information/i)).toBeVisible();
+  await expect(page.getByText(/scripted demo/i).first()).toBeVisible();
+  await expect(page.getByText(/maya is fictional/i)).toBeVisible();
   await page.getByTestId('demo-start').click();
 
-  const input = page.getByTestId('demo-chat-input');
-  await expect(input).toBeEnabled();
-  await input.fill('I want to understand how an AI interview feels.');
-  await input.press('Enter');
+  await expect(page.getByTestId('demo-progress')).toContainText('Question 1 of 3');
+  await page.getByTestId('demo-choice-project').click();
+  await expect(page.getByText(/saved it for a specific future use/i)).toBeVisible();
+  await page.getByTestId('demo-choice-project-context-lost').click();
+  await expect(page.getByText(/reason for saving had faded/i)).toBeVisible();
+  await page.getByTestId('demo-choice-project-own-note').click();
 
-  await expect(page.getByTestId('demo-message-ai')).toHaveCount(2);
-  await expect(input).toBeEnabled();
+  await expect(page.getByTestId('demo-message-ai')).toHaveCount(4);
+  await expect(page.getByTestId('demo-progress')).toContainText('Interview complete');
+  await page.getByTestId('demo-view-insight').click();
+
+  await expect(page.getByRole('heading', { name: /illustrative synthesis/i })).toBeVisible();
+  await expect(page.getByTestId('demo-insight-disclosure')).toContainText('No model analyzed Maya');
+  await expect(page.getByText(/lost context creates re-entry work/i)).toBeVisible();
+  await expect(page.getByText(/forgotten which project it was for/i)).toBeVisible();
+
+  await page.getByRole('button', { name: /trace this insight in the transcript/i }).click();
+  await expect(page.getByTestId('demo-evidence-turn')).toHaveClass(/ring-2/);
+
+  await page.reload();
+  await expect(page.getByTestId('demo-start')).toBeVisible();
   expect(apiRequests).toEqual([]);
   expect(externalRequests).toEqual([]);
 });

--- a/tests/unit/DemoSimulation.accessibility.test.tsx
+++ b/tests/unit/DemoSimulation.accessibility.test.tsx
@@ -2,12 +2,94 @@ import { fireEvent, render, screen } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
 import DemoSimulation from '@/components/DemoSimulation';
 
-describe('DemoSimulation accessibility', () => {
-  it('names the sample response input and icon-only send control', () => {
-    render(<DemoSimulation />);
-    fireEvent.click(screen.getByRole('button', { name: /start sample/i }));
+function beginDemo() {
+  fireEvent.click(screen.getByRole('button', { name: /begin scripted interview/i }));
+}
 
-    expect(screen.getByRole('textbox', { name: 'Sample response' })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Send sample response' })).toBeInTheDocument();
+function completeProjectPath() {
+  fireEvent.click(screen.getByRole('button', { name: /useful for a work project/i }));
+  fireEvent.click(screen.getByRole('button', { name: /forgotten which project/i }));
+  fireEvent.click(screen.getByRole('button', { name: /one-line note in my own words/i }));
+}
+
+describe('DemoSimulation', () => {
+  it('presents a named study, a persistent disclosure, and accessible fictional choices', () => {
+    render(<DemoSimulation />);
+
+    expect(screen.getByRole('heading', { level: 1, name: /see an interview become an insight/i })).toBeInTheDocument();
+    expect(screen.getByRole('complementary', { name: /demo disclosure/i })).toHaveTextContent(/maya is fictional/i);
+
+    beginDemo();
+
+    expect(screen.getByRole('heading', { level: 1, name: /reading lists people actually return to/i })).toBeInTheDocument();
+    expect(screen.getByRole('status')).toHaveTextContent(/question 1 of 3/i);
+    expect(screen.getByRole('group', { name: /choose maya’s response/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /useful for a work project/i })).toBeInTheDocument();
+  });
+
+  it('closes the loop from an adaptive branch to a provenance-backed researcher note', () => {
+    render(<DemoSimulation />);
+    beginDemo();
+    completeProjectPath();
+
+    expect(screen.getByRole('status')).toHaveTextContent(/interview complete/i);
+    expect(screen.getByText(/compare this account with other interviews/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /see researcher view/i })).toHaveFocus();
+
+    fireEvent.click(screen.getByRole('button', { name: /see researcher view/i }));
+
+    expect(screen.getByRole('heading', { level: 1, name: /illustrative synthesis/i })).toBeInTheDocument();
+    expect(screen.getByTestId('demo-insight-disclosure')).toHaveTextContent(/no model analyzed maya/i);
+    expect(screen.getByText(/lost context creates re-entry work/i)).toBeInTheDocument();
+    expect(screen.getByText(/forgotten which project it was for/i)).toBeInTheDocument();
+    expect(screen.getByText(/interpretation, not a research finding/i)).toBeInTheDocument();
+  });
+
+  it('keeps the alternate project evidence aligned with its branch-level interpretation', () => {
+    render(<DemoSimulation />);
+    beginDemo();
+
+    fireEvent.click(screen.getByRole('button', { name: /useful for a work project/i }));
+    fireEvent.click(screen.getByRole('button', { name: /could not remember why i had saved it/i }));
+    fireEvent.click(screen.getByRole('button', { name: /project name and the question/i }));
+    fireEvent.click(screen.getByRole('button', { name: /see researcher view/i }));
+
+    expect(screen.getByText(/could not remember why i had saved it/i)).toBeInTheDocument();
+    expect(screen.getByText(/lost context creates re-entry work/i)).toBeInTheDocument();
+    expect(screen.getByText(/reconstructing purpose becomes part of the cost/i)).toBeInTheDocument();
+  });
+
+  it('changes both the probe and the illustrative synthesis when another path is chosen', () => {
+    render(<DemoSimulation />);
+    beginDemo();
+
+    fireEvent.click(screen.getByRole('button', { name: /headline made me curious/i }));
+    expect(screen.getByText(/curiosity was enough to save it/i)).toBeInTheDocument();
+    expect(screen.getByRole('status')).toHaveTextContent(/scripted branch: fading curiosity/i);
+
+    fireEvent.click(screen.getByRole('button', { name: /dozens of saved pieces/i }));
+    fireEvent.click(screen.getByRole('button', { name: /older items quietly expire/i }));
+    fireEvent.click(screen.getByRole('button', { name: /see researcher view/i }));
+
+    expect(screen.getByText(/saved curiosity becomes undifferentiated backlog/i)).toBeInTheDocument();
+    expect(screen.getByText(/original spark restored or permission for the item to disappear/i)).toBeInTheDocument();
+  });
+
+  it('traces evidence back to the transcript and can replay from a clean path', () => {
+    render(<DemoSimulation />);
+    beginDemo();
+    completeProjectPath();
+    fireEvent.click(screen.getByRole('button', { name: /see researcher view/i }));
+
+    fireEvent.click(screen.getByRole('button', { name: /trace this insight in the transcript/i }));
+
+    expect(screen.getByTestId('demo-evidence-turn')).toHaveClass('ring-2');
+    expect(screen.getByRole('button', { name: /return to researcher note/i })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /return to researcher note/i }));
+    fireEvent.click(screen.getByRole('button', { name: /replay another path/i }));
+
+    expect(screen.getByRole('status')).toHaveTextContent(/question 1 of 3/i);
+    expect(screen.queryByText(/scripted branch: project context/i)).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## What changed

- replaces the one-turn placeholder with a deterministic three-turn synthetic interview that visibly adapts to participant choices
- adds an illustrative researcher synthesis tied to exact transcript evidence, with trace and replay controls
- clarifies that the demo is scripted, local, provider-free, and does not save responses
- reshapes the landing page around the interview-to-insight research loop and honest workspace/self-host routes
- strengthens mobile, contrast, semantic, focus, and keyboard behavior

## Verification

- `npm run check` — 63 files / 317 tests
- `npm run test:setup` — 7/7
- `DEPLOYMENT_MODE=standalone npm run test:e2e` — full demo path and zero API/external requests
- 375px and 1440px visual inspection
- axe WCAG A/AA — zero violations on landing, interview, and insight states
- two independent P0/P1 review gates — GO