### PR TITLE
Name the saved study in the Study Setup breadcrumb

### DIFF
--- a/docs/design/initiative-3-brief.md
+++ b/docs/design/initiative-3-brief.md
@@ -1,6 +1,8 @@
 # Initiative 3 — "The document is real" (Verbatim, third train)
 
-Status: APPROVED with decisions of record, 2026-09-05 (v3). Orchestrator: Fable (Claude Code). Pipeline unchanged: brief → per-slice spec → Codex build → Fable + second-model review → visual pass at 1280 and 375 → accept → commit.
+Status: APPROVED with decisions of record, 2026-09-05 (v3).
+
+> **Status (2026-09-05, end of day):** the whole train shipped to `main` in one day — Slice H (PR #13), K (#14), I (#15), L (#16), M (#17) — each built by Codex from its `slice-*-spec.md`, reviewed and visually verified at 1280 and 375, and merged on green CI. Slice N was struck (decision 4). Still owed by the owner: the iOS Safari real-device pass on the participant composer (K7) and the researcher walkthrough of the trace UI on both surfaces. First item of the next Storage train: persist the aggregate synthesis (D8, decision 5). Known follow-ups recorded in the slice handbacks: the aggregate catalogue budget (40 000 chars, round-robin) on very large studies; `UUID_V4` duplicated across `studyDraftSession.ts` and `storageService.ts`; echoing `researcherContact` on the consent page. Orchestrator: Fable (Claude Code). Pipeline unchanged: brief → per-slice spec → Codex build → Fable + second-model review → visual pass at 1280 and 375 → accept → commit.
 
 Provenance: v1 written after walking every surface in the new browser suite (52 screenshots, 1280 + 375) and an independent Opus code audit against `DIRECTION-final.md`; v2 amended by an adversarial challenge lane (verdict: proceed amended, 10 amendments, all adopted and each re-verified against source before adoption).
 

--- a/src/components/StudySetup.tsx
+++ b/src/components/StudySetup.tsx
@@ -16,6 +16,7 @@ import {
 } from '@/lib/providerRegistry';
 import { CONSENT_TEXT_PLACEHOLDER, CONSENT_TEXT_PLACEHOLDER_ERROR } from '@/lib/consentText';
 import { Button, Coordinate, Icon, Label, Notice, Rule } from '@/components/ui';
+import { useSetTrailingCrumb } from '@/components/shell/breadcrumb';
 import {
   UUID_V4,
   adoptCreateIdempotencyKey,
@@ -95,6 +96,8 @@ const StudySetup: React.FC = () => {
   const [openSections, setOpenSections] = useState<string[]>([]);
   const isEditing = (id: string) => !documentMode || openSections.includes(id);
   const openSection = (id: string) => setOpenSections((open) => (open.includes(id) ? open : [...open, id]));
+  // A saved study is a document with a name; the breadcrumb should say so rather than "New study".
+  useSetTrailingCrumb(documentMode && draft.name.trim() ? draft.name.trim() : null);
 
   // Config status (API keys)
   const [configStatus, setConfigStatus] = useState<ConfigStatus | null>(null);

--- a/src/components/shell/breadcrumb.tsx
+++ b/src/components/shell/breadcrumb.tsx
@@ -22,19 +22,21 @@ export function BreadcrumbProvider({ children }: { children: ReactNode }) {
 function useBreadcrumbContext(): BreadcrumbContextValue {
   const ctx = useContext(BreadcrumbContext);
   if (!ctx) {
-    throw new Error('useSetTrailingCrumb must be used within a BreadcrumbProvider');
+    throw new Error('Breadcrumb must be used within a BreadcrumbProvider');
   }
   return ctx;
 }
 
 export function useSetTrailingCrumb(label: string | null) {
-  const { setTrailing } = useBreadcrumbContext();
+  // Tolerant of rendering outside the shell (unit tests mount screens bare):
+  // with no provider there is no breadcrumb to name, so this is a no-op.
+  const ctx = useContext(BreadcrumbContext);
+  const setTrailing = ctx?.setTrailing;
   useEffect(() => {
+    if (!setTrailing) return;
     setTrailing(label);
     return () => setTrailing(null);
-    // Re-run whenever the caller's label changes; setTrailing is stable.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [label]);
+  }, [label, setTrailing]);
 }
 
 interface CrumbItem {
@@ -64,7 +66,7 @@ function buildTrail(pathname: string, trailing: string | null): CrumbItem[] {
   if (pathname === '/setup') {
     return [
       { label: 'Studies', href: '/studies' },
-      { label: 'New study', href: null },
+      { label: trailing ?? 'New study', href: null },
     ];
   }
 

--- a/tests/unit/ResearcherShell.test.tsx
+++ b/tests/unit/ResearcherShell.test.tsx
@@ -12,6 +12,7 @@ vi.mock('next/navigation', () => ({
 }));
 
 import ResearcherShell from '@/components/shell/ResearcherShell';
+import { useSetTrailingCrumb } from '@/components/shell/breadcrumb';
 
 beforeEach(() => {
   navigation.pathname = '/studies';
@@ -75,6 +76,23 @@ describe('ResearcherShell', () => {
     expect(within(breadcrumb).getByText('abc123')).toBeInTheDocument();
     expect(within(breadcrumb).queryByText('Studies')).not.toBeInTheDocument();
     expect(within(breadcrumb).getByRole('link', { name: 'Interviews' })).toHaveAttribute('href', '/dashboard');
+  });
+
+  it('names a saved study in the /setup breadcrumb, and says "New study" when nothing names it', () => {
+    navigation.pathname = '/setup';
+    function NamedDocument() {
+      useSetTrailingCrumb('Returning to saved research');
+      return <span>content</span>;
+    }
+    const { unmount } = render(<ResearcherShell><NamedDocument /></ResearcherShell>);
+    let breadcrumb = screen.getByRole('navigation', { name: 'Breadcrumb' });
+    expect(within(breadcrumb).getByText('Returning to saved research')).toBeInTheDocument();
+    expect(within(breadcrumb).queryByText('New study')).not.toBeInTheDocument();
+    unmount();
+
+    render(<ResearcherShell>content</ResearcherShell>);
+    breadcrumb = screen.getByRole('navigation', { name: 'Breadcrumb' });
+    expect(within(breadcrumb).getByText('New study')).toBeInTheDocument();
   });
 
   it('shows the "Your keys · your database" line', () => {


### PR DESCRIPTION
## Summary
- `/setup` breadcrumb shows the study name in document mode instead of "New study"
- `useSetTrailingCrumb` is a no-op outside a `BreadcrumbProvider` (bare component tests)
- Initiative 3 brief records the train's completion and the owed follow-ups

## Verification
- `eslint --max-warnings=0`, `tsc --noEmit`, StudySetup/shell suites green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019W1UEuh7NW4Zh5rSPyPaWp