### PR TITLE
Strip Gemini-rejected schema bounds; synthesis on gemini-3.8-flash

### DIFF
--- a/src/lib/providers/gemini.ts
+++ b/src/lib/providers/gemini.ts
@@ -64,6 +64,33 @@ export function getGeminiInteractionThinkingLevel(
   return enableReasoning ? 'high' : 'low';
 }
 
+// Gemini's Interactions API response_format.schema rejects these JSON Schema
+// keywords with a 400 (`Request contains an invalid argument`), even though
+// they are valid JSON Schema and accepted by every other provider adapter.
+// All three bounds are re-enforced server-side by src/lib/providerValidation.ts,
+// so stripping them from the WIRE schema Gemini sees loses no safety — only
+// this adapter's outbound request is affected; the shared schemas in
+// src/lib/providerSchemas.ts stay strict for every other provider.
+const GEMINI_UNSUPPORTED_SCHEMA_KEYWORDS = ['maxLength', 'minimum', 'minItems'] as const;
+
+export function toGeminiResponseSchema(schema: ProviderJsonSchema): ProviderJsonSchema {
+  function strip(value: unknown): unknown {
+    if (Array.isArray(value)) {
+      return value.map(strip);
+    }
+    if (value !== null && typeof value === 'object') {
+      const result: Record<string, unknown> = {};
+      for (const [key, entry] of Object.entries(value)) {
+        if ((GEMINI_UNSUPPORTED_SCHEMA_KEYWORDS as readonly string[]).includes(key)) continue;
+        result[key] = strip(entry);
+      }
+      return result;
+    }
+    return value;
+  }
+  return strip(schema) as ProviderJsonSchema;
+}
+
 export class GeminiProvider implements AIProvider {
   private readonly ai: GoogleGenAI;
   private readonly model: string;
@@ -107,7 +134,7 @@ export class GeminiProvider implements AIProvider {
                 response_format: {
                   type: 'text' as const,
                   mime_type: 'application/json' as const,
-                  schema: options.schema,
+                  schema: toGeminiResponseSchema(options.schema),
                 },
               }
             : {}),

--- a/src/types.ts
+++ b/src/types.ts
@@ -66,6 +66,7 @@ export interface AIModelOption {
 
 // Available Gemini models
 export const GEMINI_MODELS: AIModelOption[] = [
+  { id: 'gemini-3.8-flash', label: 'Gemini 3.8 Flash', desc: 'Newest Flash model' },
   { id: 'gemini-3.7-flash', label: 'Gemini 3.7 Flash', desc: 'Balanced capability and speed' },
   { id: 'gemini-2.5-flash', label: 'Gemini 2.5 Flash', desc: 'Fast, cost-effective' },
   { id: 'gemini-2.5-pro', label: 'Gemini 2.5 Pro', desc: 'Higher quality' },
@@ -107,7 +108,7 @@ export const DEFAULT_OPENAI_MODEL = 'gpt-5.6-terra';
 export const DEFAULT_OPENROUTER_MODEL = 'openai/gpt-5.6-terra';
 
 // Synthesis models (switch to the app's configured higher-capability model)
-export const GEMINI_SYNTHESIS_MODEL = 'gemini-3.1-pro-preview';
+export const GEMINI_SYNTHESIS_MODEL = 'gemini-3.8-flash';
 export const CLAUDE_SYNTHESIS_MODEL = 'claude-opus-5';
 export const OPENAI_SYNTHESIS_MODEL = 'gpt-5.6-sol';
 export const OPENROUTER_SYNTHESIS_MODEL = 'openai/gpt-5.6-sol';

--- a/tests/unit/providers.gemini-claude.test.ts
+++ b/tests/unit/providers.gemini-claude.test.ts
@@ -129,6 +129,28 @@ describe('GeminiProvider Interactions API', () => {
       model: 'gemini-3.1-pro-preview-2026-07-15',
     });
     expect(geminiCreateMock.mock.calls[0][0].store).toBe(false);
+
+    // Gemini's Interactions API rejects response_format schemas containing
+    // maxLength/minimum/minItems with a 400, even though synthesisResponseSchema
+    // (shared with every other provider) legitimately declares them. See
+    // toGeminiResponseSchema in src/lib/providers/gemini.ts.
+    const sentSchema = geminiCreateMock.mock.calls[0][0].response_format.schema;
+    const seenKeys = new Set<string>();
+    (function collect(value: unknown) {
+      if (Array.isArray(value)) {
+        value.forEach(collect);
+        return;
+      }
+      if (value !== null && typeof value === 'object') {
+        for (const [key, entry] of Object.entries(value)) {
+          seenKeys.add(key);
+          collect(entry);
+        }
+      }
+    })(sentSchema);
+    expect(seenKeys.has('maxLength')).toBe(false);
+    expect(seenKeys.has('minimum')).toBe(false);
+    expect(seenKeys.has('minItems')).toBe(false);
   });
 });
 

--- a/tests/unit/providers.geminiSchema.test.ts
+++ b/tests/unit/providers.geminiSchema.test.ts
@@ -1,0 +1,144 @@
+// @vitest-environment node
+
+import { describe, expect, it } from 'vitest';
+import { toGeminiResponseSchema } from '@/lib/providers/gemini';
+import {
+  aggregateSynthesisResponseSchema,
+  followupStudyResponseSchema,
+  interviewResponseSchema,
+  synthesisResponseSchema,
+  type ProviderJsonSchema,
+} from '@/lib/providerSchemas';
+
+// Gemini's Interactions API rejects response_format schemas containing these
+// JSON Schema keywords with a 400. They are re-enforced server-side by
+// src/lib/providerValidation.ts, so stripping them from the Gemini-bound wire
+// schema loses no safety. See src/lib/providers/gemini.ts.
+const REJECTED_KEYWORDS = ['maxLength', 'minimum', 'minItems'] as const;
+
+const SCHEMAS: Record<string, ProviderJsonSchema> = {
+  interviewResponseSchema,
+  synthesisResponseSchema,
+  aggregateSynthesisResponseSchema,
+  followupStudyResponseSchema,
+};
+
+function collectKeys(value: unknown, keys: Set<string>): void {
+  if (Array.isArray(value)) {
+    for (const entry of value) collectKeys(entry, keys);
+    return;
+  }
+  if (value !== null && typeof value === 'object') {
+    for (const [key, entry] of Object.entries(value)) {
+      keys.add(key);
+      collectKeys(entry, keys);
+    }
+  }
+}
+
+// Deep copy that also strips the three rejected keywords, used as an
+// independent expectation to deep-equal the sanitizer's output against.
+function stripExpected(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(stripExpected);
+  }
+  if (value !== null && typeof value === 'object') {
+    const result: Record<string, unknown> = {};
+    for (const [key, entry] of Object.entries(value)) {
+      if ((REJECTED_KEYWORDS as readonly string[]).includes(key)) continue;
+      result[key] = stripExpected(entry);
+    }
+    return result;
+  }
+  return value;
+}
+
+describe('toGeminiResponseSchema', () => {
+  for (const [name, schema] of Object.entries(SCHEMAS)) {
+    describe(name, () => {
+      it('strips every rejected keyword at every nesting level', () => {
+        const sanitized = toGeminiResponseSchema(schema);
+        const keys = new Set<string>();
+        collectKeys(sanitized, keys);
+        for (const rejected of REJECTED_KEYWORDS) {
+          expect(keys.has(rejected)).toBe(false);
+        }
+      });
+
+      it('deep-equals the source once the rejected keys are stripped', () => {
+        const sanitized = toGeminiResponseSchema(schema);
+        expect(sanitized).toEqual(stripExpected(schema));
+      });
+
+      it('does not mutate the source schema', () => {
+        const before = JSON.parse(JSON.stringify(schema));
+        toGeminiResponseSchema(schema);
+        expect(schema).toEqual(before);
+      });
+    });
+  }
+
+  it('preserves maxItems, additionalProperties: false, required, and enum where present', () => {
+    const sanitized = toGeminiResponseSchema(interviewResponseSchema);
+    expect(sanitized).toMatchObject({
+      additionalProperties: false,
+      required: [
+        'message',
+        'questionAddressed',
+        'phaseTransition',
+        'profileUpdates',
+        'shouldConclude',
+      ],
+    });
+    const sanitizedTyped = sanitized as {
+      properties: {
+        phaseTransition: { enum: unknown[] };
+        profileUpdates: { maxItems: number; items: { required: unknown[] } };
+      };
+    };
+    expect(sanitizedTyped.properties.phaseTransition.enum).toEqual([
+      'background',
+      'core-questions',
+      'exploration',
+      'feedback',
+      'wrap-up',
+      null,
+    ]);
+    expect(sanitizedTyped.properties.profileUpdates.maxItems).toBe(50);
+    expect(sanitizedTyped.properties.profileUpdates.items.required).toEqual([
+      'fieldId',
+      'value',
+      'status',
+    ]);
+  });
+
+  it('preserves maxItems and additionalProperties: false in the synthesis schema evidenceRefs', () => {
+    const sanitized = toGeminiResponseSchema(synthesisResponseSchema) as {
+      properties: {
+        themes: {
+          items: {
+            additionalProperties: boolean;
+            properties: {
+              evidenceRefs: { maxItems: number; items: { additionalProperties: boolean } };
+            };
+          };
+        };
+      };
+    };
+    expect(sanitized.properties.themes.items.additionalProperties).toBe(false);
+    expect(sanitized.properties.themes.items.properties.evidenceRefs.maxItems).toBe(3);
+    expect(
+      sanitized.properties.themes.items.properties.evidenceRefs.items.additionalProperties
+    ).toBe(false);
+  });
+
+  it('confirms the source schemas actually contain rejected keywords (sanity check)', () => {
+    const keys = new Set<string>();
+    collectKeys(synthesisResponseSchema, keys);
+    collectKeys(aggregateSynthesisResponseSchema, keys);
+    collectKeys(followupStudyResponseSchema, keys);
+    for (const rejected of REJECTED_KEYWORDS) {
+      expect(keys.has(rejected)).toBe(true);
+    }
+  });
+});


### PR DESCRIPTION
## Why
Production synthesis returned 400 from Gemini on every finalization. Live probe bisected the cause: the Interactions API rejects `maxLength`, `minimum`, and `minItems` in `response_format.schema` (accepts `maxItems`, `additionalProperties`, `enum`, `required`).

## What
- `src/lib/providers/gemini.ts`: `toGeminiResponseSchema()` deep-strips the three keywords from the outbound schema. Gemini adapter only — `providerSchemas.ts` unchanged, other providers still get the strict schema, and `providerValidation.ts` re-enforces the bounds server-side.
- `src/types.ts`: add `gemini-3.8-flash` to `GEMINI_MODELS`; `GEMINI_SYNTHESIS_MODEL` → `gemini-3.8-flash`. Gateway mapping is generic (`google/<id>`), no change needed.
- Tests: new `providers.geminiSchema.test.ts` (all four schemas sanitize clean, non-mutating, survivors preserved); `providers.gemini-claude.test.ts` asserts the actual payload sent to `interactions.create` is clean.

## Verification
`npm run check` (161 files / 1428 tests), standalone + gateway + hosted builds, `npm run test:e2e` 5/5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019W1UEuh7NW4Zh5rSPyPaWp