### PR TITLE
Refund synthesis retry budget on provider failure; honest 429 state

### DIFF
--- a/src/app/api/synthesis/route.ts
+++ b/src/app/api/synthesis/route.ts
@@ -15,7 +15,7 @@ import {
 } from '@/lib/researcherContext';
 import { loadCanonicalStudy } from '@/lib/canonicalStudy';
 import { providerErrorResponse } from '@/lib/providerErrors';
-import { participantRateLimitResponse } from '@/lib/rateLimit';
+import { participantRateLimitResponse, refundParticipantRateLimit } from '@/lib/rateLimit';
 import { hostedAiRateLimitResponse } from '@/lib/platformAiRateLimit';
 import { validateBehavior, validateProfile, validateTranscript } from '@/lib/interviewSubmission';
 import { createSynthesisReceipt } from '@/lib/synthesisReceipt';
@@ -184,6 +184,19 @@ export async function POST(request: Request) {
       }
       return NextResponse.json({ ...result.value, _receipt: receipt });
     } catch (providerError) {
+      // The participant limiter already consumed a synthesis attempt for
+      // this request; a provider-side failure isn't the participant's fault,
+      // so refund it instead of letting a bad upstream response burn their
+      // retry budget for the day.
+      if (!isAdmin) {
+        await refundParticipantRateLimit(
+          request,
+          canonical.study.id,
+          'synthesis',
+          context.kvClient,
+          { sessionId: participantSessionId, linkId, researcherId: context.researcherId }
+        );
+      }
       return providerErrorResponse(providerError);
     }
   } catch (error) {

--- a/src/components/Synthesis.tsx
+++ b/src/components/Synthesis.tsx
@@ -3,7 +3,7 @@
 import React, { useCallback, useEffect, useState, useRef } from 'react';
 import { useRouter } from 'next/navigation';
 import { useStore } from '@/store';
-import { synthesizeInterview } from '@/services/interviewApi';
+import { ApiRequestError, synthesizeInterview } from '@/services/interviewApi';
 import { saveCompletedInterview } from '@/services/storageService';
 import { Button, Coordinate, Label, Notice, Page, Rule, Verbatim } from '@/components/ui';
 import { SynthesisReading } from '@/components/SynthesisReading';
@@ -49,7 +49,9 @@ const Synthesis: React.FC = () => {
   const [isAnalyzing, setIsAnalyzing] = useState(false);
   const [isSaving, setIsSaving] = useState(false);
   const [saveStatus, setSaveStatus] = useState<'pending' | 'saved' | 'preview' | 'failed' | null>(null);
-  const [analysisError, setAnalysisError] = useState(false);
+  const [analysisError, setAnalysisError] = useState<
+    null | { kind: 'failed' } | { kind: 'rate-limited'; retryAfterSeconds: number | null }
+  >(null);
 
   const mounted = useRef(false);
   const activeAttempt = useRef<CompletionAttempt | null>(null);
@@ -117,7 +119,7 @@ const Synthesis: React.FC = () => {
   };
 
   const handleRetryAnalysis = () => {
-    setAnalysisError(false);
+    setAnalysisError(null);
     activeAttempt.current = null;
     setRetryTrigger(prev => prev + 1);
   };
@@ -135,7 +137,7 @@ const Synthesis: React.FC = () => {
     setIsAnalyzing(false);
     setIsSaving(false);
     setSaveStatus(null);
-    setAnalysisError(false);
+    setAnalysisError(null);
     if (!studyConfig || interviewHistory.length === 0) return;
 
     const attempt: CompletionAttempt = { inputs, result: existingSynthesis, saving: false };
@@ -164,7 +166,11 @@ const Synthesis: React.FC = () => {
       } catch (error) {
         if (isCurrentAttempt(attempt)) {
           console.error('Error synthesizing interview:', error);
-          setAnalysisError(true);
+          setAnalysisError(
+            error instanceof ApiRequestError && error.status === 429
+              ? { kind: 'rate-limited', retryAfterSeconds: error.retryAfterSeconds }
+              : { kind: 'failed' }
+          );
         }
       } finally {
         if (isCurrentAttempt(attempt)) setIsAnalyzing(false);
@@ -194,13 +200,15 @@ const Synthesis: React.FC = () => {
   }
 
   if (viewMode === 'participant') {
-    const participantState = analysisError
-      ? 'analysis-failed'
-      : saveStatus === 'failed' || saveStatus === 'preview'
-        ? 'save-failed'
-        : saveStatus === 'saved'
-          ? 'saved'
-          : 'finalizing';
+    const participantState = analysisError?.kind === 'rate-limited'
+      ? 'rate-limited'
+      : analysisError?.kind === 'failed'
+        ? 'analysis-failed'
+        : saveStatus === 'failed' || saveStatus === 'preview'
+          ? 'save-failed'
+          : saveStatus === 'saved'
+            ? 'saved'
+            : 'finalizing';
 
     const elapsedMs = transcriptElapsedMs(interviewHistory);
     const consentAccepted = formatConsentTimestamp(consentTimestamp);
@@ -250,6 +258,28 @@ const Synthesis: React.FC = () => {
               <Notice tone="error">
                 <p className="font-sans text-[15px] leading-[24px] text-ink-700" role="alert">
                   Your responses are still in this tab, but they have not been saved. Keep this tab open and try again.
+                </p>
+              </Notice>
+              <div className="flex flex-col gap-3 sm:flex-row">
+                <Button variant="quiet" onClick={handleBack}>
+                  Back to interview
+                </Button>
+                <Button variant="primary" onClick={handleRetryAnalysis}>
+                  Retry finalization
+                </Button>
+              </div>
+            </>
+          ) : participantState === 'rate-limited' ? (
+            <>
+              <Verbatim as="h1" className="text-[28px] font-normal leading-[36px] text-ink-900">
+                Too many finalization attempts
+              </Verbatim>
+              <Notice tone="error">
+                <p className="font-sans text-[15px] leading-[24px] text-ink-700" role="alert">
+                  Your responses are safe in this tab.{' '}
+                  {analysisError?.kind === 'rate-limited' && analysisError.retryAfterSeconds != null
+                    ? `Wait about ${Math.max(1, Math.ceil(analysisError.retryAfterSeconds / 60))} minutes, then retry — keep this tab open.`
+                    : 'Wait a few minutes, then retry — keep this tab open.'}
                 </p>
               </Notice>
               <div className="flex flex-col gap-3 sm:flex-row">

--- a/src/lib/rateLimit.ts
+++ b/src/lib/rateLimit.ts
@@ -38,7 +38,9 @@ const LIMITS: Record<ParticipantOperation, Limit[]> = {
     { scope: 'researcher', maximum: 10_000, windowSeconds: 86_400 },
   ],
   synthesis: [
-    { scope: 'session', maximum: 2, windowSeconds: 86_400 },
+    // 6: enough for a handful of legitimate retries after a provider failure,
+    // while still bounding runaway re-synthesis over a session.
+    { scope: 'session', maximum: 6, windowSeconds: 86_400 },
     { scope: 'client', maximum: 10, windowSeconds: 3_600 },
     { scope: 'link', maximum: 500, windowSeconds: 86_400 },
     { scope: 'study', maximum: 1_000, windowSeconds: 86_400 },
@@ -71,6 +73,19 @@ for i = 1, #KEYS do
 end
 
 return {1, 0, 0}
+`;
+
+// A provider failure (as opposed to a rejected/over-budget request) must not
+// cost the participant part of their retry budget. This never lowers a
+// counter below zero and never touches the key's TTL, so a refund can't
+// resurrect an expired window or extend one that's still running.
+const REFUND_LIMITS_SCRIPT = `
+for i = 1, #KEYS do
+  local count = tonumber(redis.call('GET', KEYS[i]) or '0')
+  if count > 0 then redis.call('DECR', KEYS[i]) end
+end
+
+return 1
 `;
 
 function rateLimitSalt(): string {
@@ -173,6 +188,28 @@ export async function participantRateLimitResponse(
       { error: 'Unable to verify request limits. Please try again later.', retryable: true },
       { status: 503 }
     );
+  }
+}
+
+// Undo a prior participantRateLimitResponse consumption. Called when the
+// request the limiter admitted went on to fail for a reason unrelated to the
+// participant (e.g. an upstream provider error) — the participant should not
+// lose a retry attempt for a failure that wasn't theirs. Best-effort: this
+// must never throw or surface a new failure to the caller.
+export async function refundParticipantRateLimit(
+  request: Request,
+  studyId: string,
+  operation: ParticipantOperation,
+  client: RedisPort,
+  authority: { sessionId?: string; linkId?: string; researcherId?: string | null } = {}
+): Promise<void> {
+  try {
+    const counters = getParticipantRateLimitCounters(request, studyId, operation, authority);
+    if (!counters) return;
+    const keys = counters.map(counter => counter.key);
+    await client.eval(REFUND_LIMITS_SCRIPT, keys, []);
+  } catch (error) {
+    logRequestFailure({ event: 'rateLimit.refund', operation }, error);
   }
 }
 

--- a/src/lib/requestLog.ts
+++ b/src/lib/requestLog.ts
@@ -26,6 +26,7 @@ export const REQUEST_LOG_EVENT_ALLOWLIST = [
   'platform.unavailable',
   'route.failure',
   'synthesis.evidence',
+  'rateLimit.refund',
 ] as const;
 
 export const REQUEST_LOG_REASON_ALLOWLIST = [

--- a/src/services/interviewApi.ts
+++ b/src/services/interviewApi.ts
@@ -16,6 +16,26 @@ import { buildParticipantOrPreviewHeaders } from '@/services/participantHeaders'
 // Participant authority is a short-lived HttpOnly same-site cookie. Share-link
 // codes and session credentials are never exposed to this JavaScript service.
 
+// Thrown for any non-OK API response so callers can distinguish a rate limit
+// (429, with a server-provided Retry-After) from every other failure without
+// parsing the message string.
+export class ApiRequestError extends Error {
+  constructor(
+    public readonly status: number,
+    public readonly retryAfterSeconds: number | null
+  ) {
+    super(`API error: ${status}`);
+    this.name = 'ApiRequestError';
+  }
+}
+
+function retryAfterSecondsFromResponse(response: Response): number | null {
+  const header = response.headers.get('Retry-After');
+  if (!header) return null;
+  const seconds = Number.parseInt(header, 10);
+  return Number.isFinite(seconds) && seconds >= 0 ? seconds : null;
+}
+
 // Generate AI interviewer response
 export const generateInterviewResponse = async (
   history: InterviewMessage[],
@@ -43,7 +63,7 @@ export const generateInterviewResponse = async (
     });
 
     if (!response.ok) {
-      throw new Error(`API error: ${response.status}`);
+      throw new ApiRequestError(response.status, retryAfterSecondsFromResponse(response));
     }
 
     return await response.json();
@@ -70,7 +90,7 @@ export const getInterviewGreeting = async (
     });
 
     if (!response.ok) {
-      throw new Error(`API error: ${response.status}`);
+      throw new ApiRequestError(response.status, retryAfterSecondsFromResponse(response));
     }
 
     const data = await response.json();
@@ -106,7 +126,7 @@ export const synthesizeInterview = async (
     });
 
     if (!response.ok) {
-      throw new Error(`API error: ${response.status}`);
+      throw new ApiRequestError(response.status, retryAfterSecondsFromResponse(response));
     }
 
     return await response.json();

--- a/tests/unit/Synthesis.completion.test.tsx
+++ b/tests/unit/Synthesis.completion.test.tsx
@@ -12,6 +12,15 @@ const routerMock = vi.hoisted(() => ({ push: vi.fn() }));
 
 vi.mock('@/services/interviewApi', () => ({
   synthesizeInterview: serviceMocks.synthesizeInterview,
+  ApiRequestError: class ApiRequestError extends Error {
+    status: number;
+    retryAfterSeconds: number | null;
+    constructor(status: number, retryAfterSeconds: number | null) {
+      super(`API error: ${status}`);
+      this.status = status;
+      this.retryAfterSeconds = retryAfterSeconds;
+    }
+  },
 }));
 
 vi.mock('@/services/storageService', () => ({

--- a/tests/unit/Synthesis.lifecycle.test.tsx
+++ b/tests/unit/Synthesis.lifecycle.test.tsx
@@ -7,11 +7,23 @@ import { makeStudyConfig } from '../fixtures/models';
 
 const services = vi.hoisted(() => ({ synthesizeInterview: vi.fn(), saveCompletedInterview: vi.fn() }));
 const router = vi.hoisted(() => ({ push: vi.fn() }));
-vi.mock('@/services/interviewApi', () => ({ synthesizeInterview: services.synthesizeInterview }));
+vi.mock('@/services/interviewApi', () => ({
+  synthesizeInterview: services.synthesizeInterview,
+  ApiRequestError: class ApiRequestError extends Error {
+    status: number;
+    retryAfterSeconds: number | null;
+    constructor(status: number, retryAfterSeconds: number | null) {
+      super(`API error: ${status}`);
+      this.status = status;
+      this.retryAfterSeconds = retryAfterSeconds;
+    }
+  },
+}));
 vi.mock('@/services/storageService', () => ({ saveCompletedInterview: services.saveCompletedInterview }));
 vi.mock('next/navigation', () => ({ useRouter: () => router }));
 
 import Synthesis from '@/components/Synthesis';
+import { ApiRequestError } from '@/services/interviewApi';
 
 const result: SynthesisResult = {
   statedPreferences: [], revealedPreferences: [], themes: [], contradictions: [], keyInsights: [],
@@ -225,6 +237,22 @@ describe('Synthesis signed submission lifecycle', () => {
     await screen.findByText('Interview submitted');
     expect(services.synthesizeInterview).toHaveBeenCalledTimes(3);
     expect(services.saveCompletedInterview).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows a rate-limited retry prompt distinct from a generic failure', async () => {
+    services.synthesizeInterview.mockRejectedValueOnce(new ApiRequestError(429, 900));
+    render(<Synthesis />);
+    await screen.findByText('Too many finalization attempts');
+    expect(screen.getByText(/about 15 minutes/)).toBeInTheDocument();
+    expect(screen.queryByText("We couldn't finalize your interview")).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Retry finalization' })).toBeInTheDocument();
+  });
+
+  it('falls back to generic finalization-failed copy for a non-rate-limit error', async () => {
+    services.synthesizeInterview.mockRejectedValueOnce(new Error('Unavailable'));
+    render(<Synthesis />);
+    await screen.findByText("We couldn't finalize your interview");
+    expect(screen.queryByText('Too many finalization attempts')).not.toBeInTheDocument();
   });
 
   it('offers transcript export to preview users when analysis fails', async () => {

--- a/tests/unit/Synthesis.receipt.test.tsx
+++ b/tests/unit/Synthesis.receipt.test.tsx
@@ -13,6 +13,15 @@ const routerMock = vi.hoisted(() => ({ push: vi.fn() }));
 
 vi.mock('@/services/interviewApi', () => ({
   synthesizeInterview: serviceMocks.synthesizeInterview,
+  ApiRequestError: class ApiRequestError extends Error {
+    status: number;
+    retryAfterSeconds: number | null;
+    constructor(status: number, retryAfterSeconds: number | null) {
+      super(`API error: ${status}`);
+      this.status = status;
+      this.retryAfterSeconds = retryAfterSeconds;
+    }
+  },
 }));
 
 vi.mock('@/services/storageService', () => ({

--- a/tests/unit/Synthesis.register.test.tsx
+++ b/tests/unit/Synthesis.register.test.tsx
@@ -12,6 +12,15 @@ const routerMock = vi.hoisted(() => ({ push: vi.fn() }));
 
 vi.mock('@/services/interviewApi', () => ({
   synthesizeInterview: serviceMocks.synthesizeInterview,
+  ApiRequestError: class ApiRequestError extends Error {
+    status: number;
+    retryAfterSeconds: number | null;
+    constructor(status: number, retryAfterSeconds: number | null) {
+      super(`API error: ${status}`);
+      this.status = status;
+      this.retryAfterSeconds = retryAfterSeconds;
+    }
+  },
 }));
 
 vi.mock('@/services/storageService', () => ({

--- a/tests/unit/Synthesis.sessionHeaders.test.tsx
+++ b/tests/unit/Synthesis.sessionHeaders.test.tsx
@@ -10,6 +10,15 @@ const serviceMocks = vi.hoisted(() => ({
 
 vi.mock('@/services/interviewApi', () => ({
   synthesizeInterview: serviceMocks.synthesizeInterview,
+  ApiRequestError: class ApiRequestError extends Error {
+    status: number;
+    retryAfterSeconds: number | null;
+    constructor(status: number, retryAfterSeconds: number | null) {
+      super(`API error: ${status}`);
+      this.status = status;
+      this.retryAfterSeconds = retryAfterSeconds;
+    }
+  },
 }));
 vi.mock('@/services/storageService', () => ({
   saveCompletedInterview: serviceMocks.saveCompletedInterview,

--- a/tests/unit/Synthesis.trace.test.tsx
+++ b/tests/unit/Synthesis.trace.test.tsx
@@ -13,6 +13,15 @@ const routerMock = vi.hoisted(() => ({ push: vi.fn() }));
 
 vi.mock('@/services/interviewApi', () => ({
   synthesizeInterview: serviceMocks.synthesizeInterview,
+  ApiRequestError: class ApiRequestError extends Error {
+    status: number;
+    retryAfterSeconds: number | null;
+    constructor(status: number, retryAfterSeconds: number | null) {
+      super(`API error: ${status}`);
+      this.status = status;
+      this.retryAfterSeconds = retryAfterSeconds;
+    }
+  },
 }));
 
 vi.mock('@/services/storageService', () => ({

--- a/tests/unit/api.synthesis.telemetry.test.ts
+++ b/tests/unit/api.synthesis.telemetry.test.ts
@@ -45,7 +45,10 @@ vi.mock('@/lib/providers', () => providersMock);
 const kvMock = vi.hoisted(() => ({ getStudy: vi.fn() }));
 vi.mock('@/lib/kv', () => kvMock);
 
-const rateLimitMock = vi.hoisted(() => ({ participantRateLimitResponse: vi.fn() }));
+const rateLimitMock = vi.hoisted(() => ({
+  participantRateLimitResponse: vi.fn(),
+  refundParticipantRateLimit: vi.fn(),
+}));
 vi.mock('@/lib/rateLimit', () => rateLimitMock);
 
 const platformRateLimitMock = vi.hoisted(() => ({ hostedAiRateLimitResponse: vi.fn() }));
@@ -128,6 +131,7 @@ beforeEach(() => {
   });
   kvMock.getStudy.mockResolvedValue(makeStoredStudy({ id: 'study-t', config: studyConfig }));
   rateLimitMock.participantRateLimitResponse.mockResolvedValue(null);
+  rateLimitMock.refundParticipantRateLimit.mockResolvedValue(undefined);
   platformRateLimitMock.hostedAiRateLimitResponse.mockResolvedValue(null);
   receiptMock.createSynthesisReceipt.mockResolvedValue('synthesis-receipt');
   consentMock.verifyParticipantConsent.mockResolvedValue({
@@ -196,5 +200,37 @@ describe('POST /api/synthesis evidence telemetry', () => {
     expect(events[0].refsOffered).toBe(0);
     expect(events[0].refsLocated).toBe(0);
     expect(JSON.stringify(spy.mock.calls)).not.toContain('Repeated concern');
+  });
+});
+
+describe('POST /api/synthesis participant rate-limit refund', () => {
+  it('refunds the participant synthesis budget when the provider call fails', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    providersMock.getInterviewProvider.mockReturnValue({
+      generateInterviewResponse: vi.fn(),
+      getInterviewGreeting: vi.fn(),
+      synthesizeInterview: vi.fn().mockRejectedValue(new Error('provider unavailable')),
+    });
+
+    const res = await synthesisPOST(makeRequest());
+    expect(res.status).toBeGreaterThanOrEqual(500);
+
+    expect(rateLimitMock.refundParticipantRateLimit).toHaveBeenCalledTimes(1);
+    const [, studyId, operation, , authority] = rateLimitMock.refundParticipantRateLimit.mock.calls[0];
+    expect(studyId).toBe('study-t');
+    expect(operation).toBe('synthesis');
+    expect(authority).toMatchObject({
+      sessionId: 'participant-session-t',
+      researcherId: 'researcher-t',
+    });
+  });
+
+  it('does not refund the participant synthesis budget when synthesis succeeds', async () => {
+    providersMock.getInterviewProvider.mockReturnValue(providerReturning([]));
+
+    const res = await synthesisPOST(makeRequest());
+    expect(res.status).toBe(200);
+
+    expect(rateLimitMock.refundParticipantRateLimit).not.toHaveBeenCalled();
   });
 });

--- a/tests/unit/interviewApi.rateLimitError.test.ts
+++ b/tests/unit/interviewApi.rateLimitError.test.ts
@@ -1,0 +1,86 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ApiRequestError, synthesizeInterview } from '@/services/interviewApi';
+import { makeStudyConfig } from '../fixtures/models';
+
+// synthesizeInterview et al. throw a typed ApiRequestError on any non-OK
+// response so callers (Synthesis.tsx) can distinguish a 429 rate limit —
+// with a server-provided Retry-After — from every other failure.
+
+function jsonResponse(status: number, headers: Record<string, string> = {}) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    headers: new Headers(headers),
+    json: async () => ({}),
+  } as unknown as Response;
+}
+
+const studyConfig = makeStudyConfig({ id: 'study-rate-limit' });
+
+beforeEach(() => {
+  vi.spyOn(console, 'error').mockImplementation(() => undefined);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe('interviewApi ApiRequestError', () => {
+  it('parses Retry-After into retryAfterSeconds on a 429', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(jsonResponse(429, { 'Retry-After': '900' })));
+
+    await expect(
+      synthesizeInterview([], studyConfig, { timePerTopic: {}, messagesPerTopic: {}, topicsExplored: [], contradictions: [] }, null)
+    ).rejects.toMatchObject({
+      status: 429,
+      retryAfterSeconds: 900,
+      message: 'API error: 429',
+    });
+  });
+
+  it('leaves retryAfterSeconds null when the header is missing', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(jsonResponse(429)));
+
+    await expect(
+      synthesizeInterview([], studyConfig, { timePerTopic: {}, messagesPerTopic: {}, topicsExplored: [], contradictions: [] }, null)
+    ).rejects.toMatchObject({
+      status: 429,
+      retryAfterSeconds: null,
+    });
+  });
+
+  it('leaves retryAfterSeconds null when the header is unparseable', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(jsonResponse(429, { 'Retry-After': 'not-a-number' })));
+
+    await expect(
+      synthesizeInterview([], studyConfig, { timePerTopic: {}, messagesPerTopic: {}, topicsExplored: [], contradictions: [] }, null)
+    ).rejects.toMatchObject({
+      status: 429,
+      retryAfterSeconds: null,
+    });
+  });
+
+  it('raises the same ApiRequestError shape for a non-429 failure', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(jsonResponse(500)));
+
+    await expect(
+      synthesizeInterview([], studyConfig, { timePerTopic: {}, messagesPerTopic: {}, topicsExplored: [], contradictions: [] }, null)
+    ).rejects.toMatchObject({
+      status: 500,
+      retryAfterSeconds: null,
+      message: 'API error: 500',
+    });
+  });
+
+  it('is an instance of ApiRequestError', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(jsonResponse(429, { 'Retry-After': '30' })));
+
+    try {
+      await synthesizeInterview([], studyConfig, { timePerTopic: {}, messagesPerTopic: {}, topicsExplored: [], contradictions: [] }, null);
+      expect.unreachable('expected synthesizeInterview to reject');
+    } catch (error) {
+      expect(error).toBeInstanceOf(ApiRequestError);
+    }
+  });
+});

--- a/tests/unit/rateLimit.participant.test.ts
+++ b/tests/unit/rateLimit.participant.test.ts
@@ -2,7 +2,11 @@
 
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { RedisPort } from '@/lib/redisPort';
-import { participantRateLimitResponse } from '@/lib/rateLimit';
+import {
+  getParticipantRateLimitCounters,
+  participantRateLimitResponse,
+  refundParticipantRateLimit,
+} from '@/lib/rateLimit';
 
 afterEach(() => {
   delete process.env.RATE_LIMIT_SALT;
@@ -73,5 +77,72 @@ describe('participant AI rate limiting', () => {
 
     expect(response?.status).toBe(503);
     expect(errorSpy).toHaveBeenCalled();
+  });
+
+  it('allows a handful of legitimate synthesis retries per session per day', async () => {
+    const request = new Request('http://localhost/api/synthesis');
+    const counters = getParticipantRateLimitCounters(request, 'study-a', 'synthesis', {
+      sessionId: 'session-a',
+      linkId: 'link-a',
+      researcherId: 'researcher-a',
+    });
+    const sessionCounter = counters?.find(counter => counter.key.includes(':session:'));
+    expect(sessionCounter?.maximum).toBe(6);
+    expect(sessionCounter?.windowSeconds).toBe(86_400);
+  });
+
+  describe('refundParticipantRateLimit', () => {
+    it('evaluates a guarded decrement against the same keys the limiter checks', async () => {
+      const evalMock = vi.fn().mockResolvedValue(1);
+      const client = { eval: evalMock } as unknown as RedisPort;
+      const request = new Request('http://localhost/api/synthesis', {
+        headers: { 'x-forwarded-for': '203.0.113.9' },
+      });
+      const authority = { sessionId: 'session-a', linkId: 'link-a', researcherId: 'researcher-a' };
+
+      await refundParticipantRateLimit(request, 'study-a', 'synthesis', client, authority);
+
+      const expectedKeys = getParticipantRateLimitCounters(request, 'study-a', 'synthesis', authority)!
+        .map(counter => counter.key);
+      expect(evalMock).toHaveBeenCalledTimes(1);
+      const [script, keys, args] = evalMock.mock.calls[0] as [string, string[], string[]];
+      expect(script).toContain('if count > 0 then');
+      expect(script).toContain("redis.call('DECR', KEYS[i])");
+      expect(keys).toEqual(expectedKeys);
+      expect(args).toEqual([]);
+    });
+
+    it('swallows a throwing client instead of rejecting', async () => {
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+      const client = {
+        eval: vi.fn().mockRejectedValue(new Error('redis down')),
+      } as unknown as RedisPort;
+
+      await expect(
+        refundParticipantRateLimit(
+          new Request('http://localhost/api/synthesis'),
+          'study-a',
+          'synthesis',
+          client,
+          { sessionId: 'session-a', linkId: 'link-a' }
+        )
+      ).resolves.toBeUndefined();
+      expect(errorSpy).toHaveBeenCalled();
+    });
+
+    it('returns silently when authority is incomplete', async () => {
+      const evalMock = vi.fn();
+      const client = { eval: evalMock } as unknown as RedisPort;
+
+      await refundParticipantRateLimit(
+        new Request('http://localhost/api/synthesis'),
+        'study-a',
+        'synthesis',
+        client,
+        {}
+      );
+
+      expect(evalMock).not.toHaveBeenCalled();
+    });
   });
 });


### PR DESCRIPTION
## Why
After the Gemini schema 400s (#21), the affected participant session could never finalize: `LIMITS.synthesis` session scope was 2/24h, failed attempts counted against it, and the client showed 429 as "We couldn't finalize your interview" with a Retry that always got 429 again (12 consecutive 429s in prod logs).

## What
- `src/lib/rateLimit.ts`: session synthesis cap 2 → 6; new `refundParticipantRateLimit` (atomic guarded-DECR Lua, never below 0, TTL untouched, never throws).
- `src/app/api/synthesis/route.ts`: refund in the provider-failure branch for non-admin requests only. No refund on pre-limiter 4xx or on success.
- `src/lib/requestLog.ts`: allowlist `rateLimit.refund` (counts-only).
- `src/services/interviewApi.ts`: `ApiRequestError { status, retryAfterSeconds }`, message unchanged.
- `src/components/Synthesis.tsx`: `analysisError` is now a discriminated union; new participant state "Too many finalization attempts — your responses are safe in this tab. Wait about N minutes, then retry."

## Tests
rateLimit.participant (cap, refund script, swallow), api.synthesis.telemetry (refund on reject / not on success), new interviewApi.rateLimitError, Synthesis.lifecycle (rate-limited vs failed copy). `npm run check` 162 files / 1441 tests; standalone build; e2e 5/5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019W1UEuh7NW4Zh5rSPyPaWp