### PR TITLE
Strip maxItems from Gemini response schemas

### DIFF
--- a/src/lib/providers/gemini.ts
+++ b/src/lib/providers/gemini.ts
@@ -65,13 +65,14 @@ export function getGeminiInteractionThinkingLevel(
 }
 
 // Gemini's Interactions API response_format.schema rejects these JSON Schema
+// keywords (maxItems confirmed by live bisect 2026-09-05 on gemini-3.8-flash)
 // keywords with a 400 (`Request contains an invalid argument`), even though
 // they are valid JSON Schema and accepted by every other provider adapter.
 // All three bounds are re-enforced server-side by src/lib/providerValidation.ts,
 // so stripping them from the WIRE schema Gemini sees loses no safety — only
 // this adapter's outbound request is affected; the shared schemas in
 // src/lib/providerSchemas.ts stay strict for every other provider.
-const GEMINI_UNSUPPORTED_SCHEMA_KEYWORDS = ['maxLength', 'minimum', 'minItems'] as const;
+const GEMINI_UNSUPPORTED_SCHEMA_KEYWORDS = ['maxLength', 'minimum', 'minItems', 'maxItems'] as const;
 
 export function toGeminiResponseSchema(schema: ProviderJsonSchema): ProviderJsonSchema {
   function strip(value: unknown): unknown {

--- a/tests/unit/providers.geminiSchema.test.ts
+++ b/tests/unit/providers.geminiSchema.test.ts
@@ -14,7 +14,7 @@ import {
 // JSON Schema keywords with a 400. They are re-enforced server-side by
 // src/lib/providerValidation.ts, so stripping them from the Gemini-bound wire
 // schema loses no safety. See src/lib/providers/gemini.ts.
-const REJECTED_KEYWORDS = ['maxLength', 'minimum', 'minItems'] as const;
+const REJECTED_KEYWORDS = ['maxLength', 'minimum', 'minItems', 'maxItems'] as const;
 
 const SCHEMAS: Record<string, ProviderJsonSchema> = {
   interviewResponseSchema,
@@ -78,7 +78,7 @@ describe('toGeminiResponseSchema', () => {
     });
   }
 
-  it('preserves maxItems, additionalProperties: false, required, and enum where present', () => {
+  it('preserves additionalProperties: false, required, and enum where present', () => {
     const sanitized = toGeminiResponseSchema(interviewResponseSchema);
     expect(sanitized).toMatchObject({
       additionalProperties: false,
@@ -93,7 +93,7 @@ describe('toGeminiResponseSchema', () => {
     const sanitizedTyped = sanitized as {
       properties: {
         phaseTransition: { enum: unknown[] };
-        profileUpdates: { maxItems: number; items: { required: unknown[] } };
+        profileUpdates: { maxItems?: number; items: { required: unknown[] } };
       };
     };
     expect(sanitizedTyped.properties.phaseTransition.enum).toEqual([
@@ -104,7 +104,7 @@ describe('toGeminiResponseSchema', () => {
       'wrap-up',
       null,
     ]);
-    expect(sanitizedTyped.properties.profileUpdates.maxItems).toBe(50);
+    expect(sanitizedTyped.properties.profileUpdates.maxItems).toBeUndefined();
     expect(sanitizedTyped.properties.profileUpdates.items.required).toEqual([
       'fieldId',
       'value',
@@ -112,21 +112,21 @@ describe('toGeminiResponseSchema', () => {
     ]);
   });
 
-  it('preserves maxItems and additionalProperties: false in the synthesis schema evidenceRefs', () => {
+  it('preserves additionalProperties: false in the synthesis schema evidenceRefs', () => {
     const sanitized = toGeminiResponseSchema(synthesisResponseSchema) as {
       properties: {
         themes: {
           items: {
             additionalProperties: boolean;
             properties: {
-              evidenceRefs: { maxItems: number; items: { additionalProperties: boolean } };
+              evidenceRefs: { maxItems?: number; items: { additionalProperties: boolean } };
             };
           };
         };
       };
     };
     expect(sanitized.properties.themes.items.additionalProperties).toBe(false);
-    expect(sanitized.properties.themes.items.properties.evidenceRefs.maxItems).toBe(3);
+    expect(sanitized.properties.themes.items.properties.evidenceRefs.maxItems).toBeUndefined();
     expect(
       sanitized.properties.themes.items.properties.evidenceRefs.items.additionalProperties
     ).toBe(false);


### PR DESCRIPTION
## Why
After #21 production synthesis still returned 400 from Gemini (4× `provider.failure status=400` in prod logs). A live bisect on `gemini-3.8-flash` showed the sanitized synthesis schema fails and `-maxItems` alone makes it pass; `additionalProperties`, `required`, and `integer` are fine.

## What
- `GEMINI_UNSUPPORTED_SCHEMA_KEYWORDS` gains `maxItems`.
- `providers.geminiSchema.test.ts` updated: `maxItems` is now asserted stripped; survivors (`additionalProperties`, `required`, `enum`) still asserted.

Array bounds remain enforced server-side by `providerValidation.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019W1UEuh7NW4Zh5rSPyPaWp