### PR TITLE
Harden analysis recovery, concurrency, and provider output handling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,7 +68,8 @@ Hosted study create/delete is a durable cross-database operation. Preserve the o
 - Opaque participant links: `src/lib/participantLinks.ts`
 - Server-recorded consent: `src/lib/participantConsent.ts`
 - Canonical study loading: `src/lib/canonicalStudy.ts`
-- Synthesis/save binding: `src/lib/synthesisReceipt.ts`, `src/lib/interviewSubmission.ts`
+- Save validation and deferred analysis: `src/lib/interviewSubmission.ts`, `src/lib/interviewAnalysis.ts`, `src/lib/analysisState.ts`
+- Server-generated synthesis provenance: `src/lib/synthesisProvenance.ts`
 - Bounded request parsing: `src/lib/requestBody.ts`
 - Providers and prompts: `src/lib/providers/`, `src/lib/prompts/`, `src/lib/ai.ts`
 - Transport selection and Gateway model mapping: `src/lib/aiTransport.ts`, `src/lib/providers/gateway.ts`
@@ -78,7 +79,7 @@ Hosted study create/delete is a durable cross-database operation. Preserve the o
 - Browser API clients: `src/services/`
 - Session-scoped workflow state: `src/store.ts`
 
-The participant sequence is link exchange -> HttpOnly participant session -> consent -> greeting/interview -> synthesis receipt -> immutable save. Every participant route must re-resolve authority and the server-owned current study revision before provider use or persistence.
+The participant sequence is link exchange -> HttpOnly participant session -> consent -> greeting/interview -> transcript save -> deferred analysis. The saved transcript is immutable; analysis attaches under an atomic claim and can be retried by the researcher. Every participant route must re-resolve authority and the server-owned current study revision before provider use or persistence.
 
 ## Non-negotiable invariants
 
@@ -106,7 +107,7 @@ The participant sequence is link exchange -> HttpOnly participant session -> con
 | Auth/participant authority | `auth.ts`, `proxy.ts`, `researcherContext.ts`, participant libraries | matching auth/consent/link tests + `npm run check` |
 | Storage/tenancy | `kv.ts`, `kvClient.ts`, `platformDb.ts`, reconciler | atomicity/tenancy/saga tests + `npm run check` |
 | Providers/provenance | `aiTransport.ts`, `providers/`, `prompts/`, interview/synthesis routes | transport/provider/provenance tests + direct/Gateway build contracts + `npm run check` |
-| Completion and export | `Synthesis.tsx`, `synthesisReceipt.ts`, save/export routes, `storageService.ts` | receipt/lifecycle/save tests + `npm run test:e2e` through researcher and participant workflows |
+| Completion and export | `Synthesis.tsx`, `interviewAnalysis.ts`, save/analyze/export routes, `storageService.ts` | lifecycle/save/analysis tests + `npm run test:e2e` through researcher and participant workflows |
 | Structured request logs | `src/lib/requestLog.ts`, `providerErrors.ts`, API catch sites | `requestLog.test.ts` + `providerErrors.test.ts` + health/config contract tests |
 | Participant/preview headers | `src/services/participantHeaders.ts`, `interviewApi.ts`, `storageService.ts`, `Consent.tsx` | `participantHeaders.test.ts` + `participantSessionHeaders.test.ts` + consent/isolation suites |
 | Researcher UI | components, services, page entry | paired component/API tests; inspect 375px when layout changes |
@@ -114,7 +115,7 @@ The participant sequence is link exchange -> HttpOnly participant session -> con
 
 Vitest tests live in two tiers. `tests/unit/` runs under the base vitest config (jsdom) and mirrors the security or product boundary it protects; prefer a realistic regression at that boundary over snapshots of implementation detail. `tests/integration/` runs under `vitest.integration.config.mts` (node environment) against a runner-owned disposable `redis-server` via `tests/helpers/disposableRedis.ts` — it must never connect to an inherited, shared, or production Redis. Use `npm run test:redis-crash` and `npm run test:adversarial` for these suites; they need a local `redis-server` binary (or the CI container) and are the only place real-wire crash-cut and cross-tenant claims are actually exercised.
 
-`tests/e2e/` runs the browser journeys with real application API handlers and disposable Redis; only external provider HTTP responses are synthetic. `tests/e2e/server.mjs` builds and boots the production app with a blank, credential-free fixture environment (one server per transport) and `tests/e2e/workflow-fixture.ts` intercepts Upstash and provider HTTP at Next's test-mode boundary — together they are the sanctioned way to exercise the full researcher and participant workflow locally without any real credentials. Keep the Next test proxy confined to its test-only server launcher. Do not mock internal synthesis/save APIs in the successful completion regression: it must exercise receipt creation and verification across that boundary. The keyless demo regression still requires no API or external requests.
+`tests/e2e/` runs the browser journeys with real application API handlers and disposable Redis; only external provider HTTP responses are synthetic. `tests/e2e/server.mjs` builds and boots the production app with a blank, credential-free fixture environment (one server per transport) and `tests/e2e/workflow-fixture.ts` intercepts Upstash and provider HTTP at Next's test-mode boundary — together they are the sanctioned way to exercise the full researcher and participant workflow locally without any real credentials. Keep the Next test proxy confined to its test-only server launcher. Do not mock internal save/analyze APIs in the completion regression: it must exercise transcript persistence, deferred analysis, and researcher recovery across that boundary. The keyless demo regression still requires no API or external requests.
 
 ## Canonical commands
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,7 +44,7 @@ git diff --check
 
 Changes to hosted configuration, auth, tenancy, storage, or provider resolution must also pass a hosted production build using the safe fixture environment in `.github/workflows/ci.yml`.
 
-For completion, synthesis, persistence, or export changes, run the browser workflow suite as well as focused unit tests. Its direct and Gateway journeys connect the real API handlers, signed synthesis receipts, and disposable Redis persistence; mocking each service independently can hide incompatible contracts. Run with Docker or a local `redis-server`, and unset inherited Redis connection/attestation variables. Provider HTTP responses are synthetic, so no provider key or paid request is needed.
+For completion, synthesis, persistence, or export changes, run the browser workflow suite as well as focused unit tests. Its direct and Gateway journeys connect the real save and analysis API handlers with disposable Redis persistence, including recovery after analysis fails; mocking each service independently can hide incompatible contracts. Run with Docker or a local `redis-server`, and unset inherited Redis connection/attestation variables. Provider HTTP responses are synthetic, so no provider key or paid request is needed.
 
 ## Pull requests
 

--- a/README.md
+++ b/README.md
@@ -233,9 +233,11 @@ For participants:
 1. Open the study link.
 2. Review the study information and give consent.
 3. Complete the adaptive interview.
-4. Choose **Continue to save interview** and wait for **Interview submitted** before closing the tab.
+4. Choose **Continue to save interview** and wait for **Your responses have been saved. It is now safe to close this tab.** before closing the tab.
 
-Finalization generates the synthesis and then saves the interview. If either step fails, keep the tab open and use **Retry finalization** or **Retry save**. A successful synthesis alone is not a save confirmation. Researchers can download the saved transcript and JSON from the interview detail view. Researcher previews do not store research records; if preview analysis fails, **Export transcript** still opens the transcript download.
+Finishing saves the transcript before starting analysis in the background. If the save fails, keep the tab open and use **Retry save**. Once the save is confirmed, the participant can close the tab even if analysis is still pending or fails. Researchers can use **Run analysis** on an interview or the pending-analysis batch action on a study to recover unfinished analysis. The saved transcript and JSON remain available from the interview detail view. Researchers can also customize the participant thank-you text in study setup.
+
+Analysis uses the study's current configured provider and model, including when the study was edited after collection; the result records the study revision used. Each interview separately records the provider and model configured when it was saved. Researcher previews do not store research records; if preview analysis fails, **Export transcript** still opens the transcript download.
 
 Editing a study advances its revision and invalidates links and participant sessions issued for the previous revision. Generate and distribute a new link after a consequential edit.
 
@@ -296,7 +298,7 @@ npm run test:adversarial
 git diff --check
 ```
 
-The browser suite covers the keyless demo plus standalone direct and Gateway research workflows: study creation, participant-link exchange, consent, interview, synthesis, saving, researcher review, and export. The workflow tests run the real application APIs with synthetic provider HTTP responses and a fresh disposable Redis instance per test. They require Docker or a local `redis-server`; inherited `REDIS_URL` or Redis attestation configuration is refused. Test-only servers use fixture credentials and Next's test proxy; the deployed application does not enable that proxy. These tests verify application behavior, not live provider availability, model quality, or hosted OAuth onboarding.
+The browser suite covers the keyless demo plus standalone direct and Gateway research workflows: study creation, participant-link exchange, consent, interview, saving, deferred analysis, researcher recovery and review, and export. The workflow tests run the real application APIs with synthetic provider HTTP responses and a fresh disposable Redis instance per test. They require Docker or a local `redis-server`; inherited `REDIS_URL` or Redis attestation configuration is refused. Test-only servers use fixture credentials and Next's test proxy; the deployed application does not enable that proxy. These tests verify application behavior, not live provider availability, model quality, or hosted OAuth onboarding.
 
 Production logs are allowlisted JSON and never contain prompts, keys, or bodies. Real-Redis crash and shared-BYOS adversarial jobs also refuse inherited production Redis connections.
 

--- a/docs/maintenance-review-2026-09-06.md
+++ b/docs/maintenance-review-2026-09-06.md
@@ -1,0 +1,86 @@
+# Maintenance review — 2026-09-06
+
+Four parallel reviews covered the recent save-first work, analysis storage,
+researcher recovery, and provider adapters. The starting revision was `bdd87e7`.
+The clean baseline passed lint, typecheck, and 1,511 unit tests. This review used
+source code and synthetic local fixtures; it did not inspect a live deployment
+or call a paid provider.
+
+## Assessment of the recent Claude changes
+
+The core solutions are sound within the reviewed source and test boundaries:
+
+- `7438d08` saves the transcript before scheduling analysis, retains participant
+  authority and researcher ownership checks, and uses an atomic claim to prevent
+  stale writers. Its `after()` usage matches the installed Next.js documentation.
+  The specification explicitly permits a researcher to analyze an older interview
+  with the current study configuration.
+- `6610af3` applies the study-selected model to interview synthesis, aggregate
+  synthesis, and follow-up generation across all five adapters.
+- `d73bde7` and `62ef595` limit schema sanitization to the direct Gemini adapter;
+  the removed schema bounds remain enforced by runtime validation.
+
+The save-first review found recovery and concurrency edge cases despite the
+passing baseline. The parser and missing-model issues below predate those changes.
+
+## Changes
+
+| Change | Reason and verification boundary |
+| --- | --- |
+| Count attempts in the atomic Redis script | A delayed contender could read an old count and later overwrite newer attempt history. A deterministic real-Redis interleaving now covers this race, lease takeover, and stale writes. Completion and failure preserve the attempt-start timestamp. |
+| Remove redundant transcript reads | Claim, completion, and failure each use one Redis command instead of a GET followed by EVAL. A normal analysis pipeline uses three storage commands instead of five, excluding route authorization and study loading. This is a command-count reduction, not a measured production latency claim. |
+| Preserve storage uncertainty | Redis outages return retryable HTTP 503. A provider failure is reported as recorded only after its conditional write succeeds. Lost write responses respect an already-completed record instead of reporting a false failure. |
+| Share a typed analysis client | Both researcher screens handle HTTP, network, and malformed-response failures consistently. A batch stops on a request failure and retains its loaded register; a recorded per-interview provider failure still allows the remaining batch to proceed. |
+| Recover from standalone detail URLs | The analysis request uses the fetched interview's study id, including when the original detail URL has no study query. |
+| Preserve JSON string content | The shared parser tracks quoting and escapes, so braces and embedded Markdown fences inside valid provider output remain intact. Malformed output still fails validation. |
+| Require actual served-model metadata | Direct adapters reject missing or blank response models instead of substituting the requested alias. Regression cases cover all four direct adapters and preserve dated model snapshots. |
+| Name provenance by its current responsibility | `synthesisReceipt.ts` becomes `synthesisProvenance.ts`; the remaining validator no longer suggests that signed browser receipts are part of completion. README and contributor/agent guidance now describe save-first behavior. |
+
+## Dependency and architecture decisions
+
+Dependencies remain unchanged. Registry checks found newer releases, while both
+the production and complete npm audits reported no vulnerabilities. None of the
+selected fixes needs a package upgrade. The existing Tailwind 3 compatibility
+choice and the previous review's migration boundaries remain in place.
+
+The shared client and provenance module address current responsibilities without
+splitting the larger components or storage module solely by line count. Wider
+modularization and package migrations remain separate work requiring a concrete
+behavioral or compatibility benefit.
+
+## Verification
+
+Completed with Node 24.19.0, a fresh `npm ci`, no inherited application
+credentials, CI fixture configuration, and runner-owned disposable Redis:
+
+- `npm run check`: lint, typecheck, and 172 unit files / 1,565 tests passed.
+- `npm run test:setup`: 17 tests passed; demo, standalone direct, Gateway, and
+  hosted setup contracts passed.
+- Full and production npm audits: zero vulnerabilities.
+- Standalone direct, standalone Gateway, and hosted production builds passed.
+  The direct build was the browser launcher's production-build prerequisite.
+- `npm run test:e2e`: all five Chromium scenarios passed on the final run.
+  The real application routes cover save-first completion, deferred failure,
+  researcher recovery without a study query, storage refusals in single and
+  batch analysis, export, and aggregate synthesis. Both researcher error
+  surfaces were visually inspected at 375px and passed overflow checks.
+- `npm run test:redis-crash`: 30 tests passed; `npm run test:adversarial`:
+  24 tests passed.
+- Independent reviews of the final storage, API, and UI changes found no
+  unresolved actionable issues. `git diff --check` passed.
+
+The first expanded browser run exposed an assertion that also matched Next's
+page-announcement alert. Scoping it to the analysis panel fixed the test; the
+application had already completed recovery successfully.
+
+## Operational scope
+
+There is no storage migration or participant workflow change. Existing counters
+that were previously undercounted cannot be reconstructed; future attempts
+increment the stored count atomically. Missing served-model metadata now causes
+an analysis failure, retaining the transcript for researcher recovery.
+
+The work is isolated on `codex/maintenance-review-20260906` at
+`/Users/xulelin/.codex/worktrees/openinterviewer-review-20260906`. The original
+checkout's untracked duplicate files and user-owned `.claude/` directory were
+preserved. No credentials, external data, push, merge, or deployment were involved.

--- a/src/app/api/interviews/[id]/analyze/route.ts
+++ b/src/app/api/interviews/[id]/analyze/route.ts
@@ -85,7 +85,14 @@ export async function POST(
       platformAuthority: { researcherId: gated.researcherId },
     });
 
-    // A failed analysis is a successful report of a failure: the researcher
+    if (outcome.status === 'unavailable') {
+      return NextResponse.json(
+        { error: 'Interview storage is temporarily unavailable. Please try again.', retryable: true },
+        { status: 503 },
+      );
+    }
+
+    // A recorded failed analysis is a successful report of a failure: the researcher
     // is being told a record fact, not a provider fact. 200 for all four.
     // `not-found` only arises from a race between the tenancy check above
     // and the claim itself (the interview vanished mid-request); it is

--- a/src/app/api/studies/[id]/generate-followup/route.ts
+++ b/src/app/api/studies/[id]/generate-followup/route.ts
@@ -16,7 +16,7 @@ import { AggregateSynthesisResult, StudyConfig } from '@/types';
 import { validateResolvedAggregateSynthesis } from '@/lib/providerValidation';
 import { hostedAiRateLimitResponse } from '@/lib/platformAiRateLimit';
 import { providerErrorResponse } from '@/lib/providerErrors';
-import { aggregateProvenance } from '@/lib/synthesisReceipt';
+import { aggregateProvenance } from '@/lib/synthesisProvenance';
 import { createRequestId, logRequestFailure } from '@/lib/requestLog';
 
 export async function POST(

--- a/src/app/api/synthesis/aggregate/route.ts
+++ b/src/app/api/synthesis/aggregate/route.ts
@@ -13,7 +13,7 @@ import { configurationRequiredResponse } from '@/lib/researcherAccess';
 import { getStudyChecked, getStudyInterviewsChecked, saveStudyAggregate } from '@/lib/kv';
 import { mapCollectionLoad, mapStudyLoad } from '@/lib/ownedStudies';
 import { providerErrorResponse } from '@/lib/providerErrors';
-import { aggregateProvenance } from '@/lib/synthesisReceipt';
+import { aggregateProvenance } from '@/lib/synthesisProvenance';
 import { hostedAiRateLimitResponse } from '@/lib/platformAiRateLimit';
 import { AggregateSynthesisResult, AggregateTheme, StoredAggregateSynthesis, SynthesisResult } from '@/types';
 import { readBoundedJsonObject } from '@/lib/requestBody';

--- a/src/components/InterviewDetail.tsx
+++ b/src/components/InterviewDetail.tsx
@@ -4,6 +4,7 @@ import React, { useCallback, useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { InterviewAnalysisFailureKind, StoredInterview } from '@/types';
 import { getInterview, StudyOperationPendingError } from '@/services/storageService';
+import { analyzeInterview } from '@/services/analysisApi';
 import ReactMarkdown from 'react-markdown';
 import { Button, Coordinate, Label, Notice, Tabs, Turn, type TabItem } from '@/components/ui';
 import { SynthesisReading, ProvenanceFooter } from '@/components/SynthesisReading';
@@ -54,6 +55,7 @@ const InterviewDetail: React.FC<InterviewDetailProps> = ({ interviewId, studyId,
   const [tracedTurn, setTracedTurn] = useState<number | null>(null);
   const [openNotes, setOpenNotes] = useState<Record<string, boolean>>({});
   const [isRunningAnalysis, setIsRunningAnalysis] = useState(false);
+  const [analysisRequestError, setAnalysisRequestError] = useState<string | null>(null);
   // `Date.now()` is impure and may not be called during render; a running
   // analysis's lease elapsing is exactly the kind of clock-driven UI change
   // that needs its own tick, polled while (and only while) a claim is live.
@@ -108,6 +110,7 @@ const InterviewDetail: React.FC<InterviewDetailProps> = ({ interviewId, studyId,
   useEffect(() => {
     setOpenNotes({});
     setTracedTurn(null);
+    setAnalysisRequestError(null);
   }, [interviewId]);
 
   // Landing on a cited turn from an aggregate citation's link (L11). Declared
@@ -128,18 +131,16 @@ const InterviewDetail: React.FC<InterviewDetailProps> = ({ interviewId, studyId,
   }, [interview, turn]);
 
   const handleRunAnalysis = async () => {
-    if (!interview || !studyId || isRunningAnalysis) return;
+    if (!interview || isRunningAnalysis) return;
     setIsRunningAnalysis(true);
+    setAnalysisRequestError(null);
     try {
-      const response = await fetch(
-        `/api/interviews/${encodeURIComponent(interview.id)}/analyze?studyId=${encodeURIComponent(studyId)}`,
-        { method: 'POST' },
-      );
-      if (response.ok) {
+      const result = await analyzeInterview(interview.id, interview.studyId);
+      if (result.ok) {
         await loadInterview();
+      } else {
+        setAnalysisRequestError(result.error);
       }
-    } catch (error) {
-      console.error('Error running analysis:', error);
     } finally {
       setIsRunningAnalysis(false);
     }
@@ -316,6 +317,11 @@ const InterviewDetail: React.FC<InterviewDetailProps> = ({ interviewId, studyId,
           </ol>
         ) : (
           <div>
+            {analysisRequestError && (
+              <Notice tone="error" eyebrow="Analysis request failed" role="alert" className="mb-6">
+                <p className="mt-1 text-[13px] text-ink-700">{analysisRequestError}</p>
+              </Notice>
+            )}
             {(() => {
               const status = analysisStatus(interview);
               if (status === 'complete' && interview.synthesis) {

--- a/src/components/StudyDetail.tsx
+++ b/src/components/StudyDetail.tsx
@@ -12,6 +12,7 @@ import {
   ResearcherStorageUnavailableError,
   StudyOperationPendingError,
 } from '@/services/storageService';
+import { analyzeInterview } from '@/services/analysisApi';
 import { Button, Coordinate, Icon, Label, Notice, Rule, Tabs } from '@/components/ui';
 import { AggregateReading, ProvenanceFooter } from '@/components/SynthesisReading';
 import { shortInterviewId } from '@/lib/interviewId';
@@ -131,27 +132,34 @@ const StudyDetail: React.FC<StudyDetailProps> = ({ studyId }) => {
   );
   const [isBatchAnalyzing, setIsBatchAnalyzing] = useState(false);
   const [batchProgress, setBatchProgress] = useState<{ done: number; total: number } | null>(null);
+  const [batchError, setBatchError] = useState<string | null>(null);
 
   const handleAnalyzeBatch = async () => {
     if (operationPending || isBatchAnalyzing) return;
     const batch = pendingAnalysisInterviews.slice(0, ANALYSIS_BATCH_LIMIT);
     if (batch.length === 0) return;
     setIsBatchAnalyzing(true);
+    setBatchError(null);
     setBatchProgress({ done: 0, total: batch.length });
-    for (let i = 0; i < batch.length; i++) {
-      try {
-        await fetch(
-          `/api/interviews/${encodeURIComponent(batch[i].id)}/analyze?studyId=${encodeURIComponent(studyId)}`,
-          { method: 'POST' },
-        );
-      } catch (error) {
-        console.error('Error analyzing interview:', error);
+    try {
+      for (let i = 0; i < batch.length; i++) {
+        const result = await analyzeInterview(batch[i].id, studyId);
+        if (!result.ok) {
+          setBatchError(result.error);
+          if (result.kind === 'pending') setOperationPending(true);
+          // Retain the loaded register and its error during an outage: a
+          // follow-up read could fail too and replace it with an empty state.
+          return;
+        }
+        // A recorded provider failure is a completed request. Keep going;
+        // only a request-level failure stops this user-triggered batch.
+        setBatchProgress({ done: i + 1, total: batch.length });
       }
-      setBatchProgress({ done: i + 1, total: batch.length });
+      await loadStudyData();
+    } finally {
+      setIsBatchAnalyzing(false);
+      setBatchProgress(null);
     }
-    setIsBatchAnalyzing(false);
-    setBatchProgress(null);
-    await loadStudyData();
   };
 
   const loadParticipantLinks = useCallback(async () => {
@@ -650,6 +658,12 @@ const StudyDetail: React.FC<StudyDetailProps> = ({ studyId }) => {
         ) : (
           <div>
             <ConductingModelsNotice conductingModels={conductingModels} recordedModelCount={recordedModelCount} />
+
+            {batchError && (
+              <Notice tone="error" eyebrow="Analysis batch stopped" role="alert" className="mb-4">
+                <p className="mt-1 text-[13px] text-ink-700">{batchError}</p>
+              </Notice>
+            )}
 
             {pendingAnalysisInterviews.length > 0 && (
               <div className="mb-4">

--- a/src/lib/ai.ts
+++ b/src/lib/ai.ts
@@ -73,29 +73,34 @@ export {
   followupStudyResponseSchema,
 } from './providerSchemas';
 
-// Clean JSON from AI response
+// Extract the JSON payload from optional provider prose or outer code fences.
+// Delimiters and markdown inside JSON strings are research content, not syntax
+// to strip. Leave incomplete or mismatched JSON for the caller to reject.
 export const cleanJSON = (text: string): string => {
   if (!text) return '{}';
-  let cleaned = text.replace(/```json\s*/g, '').replace(/```\s*/g, '').trim();
+  const cleaned = text.trim();
+  const start = cleaned.search(/[\[{]/);
+  if (start === -1) return cleaned;
 
-  const firstBracket = cleaned.indexOf('[');
-  const firstBrace = cleaned.indexOf('{');
+  const closingDelimiters: string[] = [];
+  let inString = false;
+  let escaped = false;
 
-  if (firstBracket !== -1 && (firstBrace === -1 || firstBracket < firstBrace)) {
-    let depth = 0;
-    for (let i = firstBracket; i < cleaned.length; i++) {
-      if (cleaned[i] === '[') depth++;
-      if (cleaned[i] === ']') depth--;
-      if (depth === 0) return cleaned.substring(firstBracket, i + 1);
+  for (let i = start; i < cleaned.length; i++) {
+    const character = cleaned[i];
+    if (inString) {
+      if (escaped) escaped = false;
+      else if (character === '\\') escaped = true;
+      else if (character === '"') inString = false;
+      continue;
     }
-  }
 
-  if (firstBrace !== -1) {
-    let depth = 0;
-    for (let i = firstBrace; i < cleaned.length; i++) {
-      if (cleaned[i] === '{') depth++;
-      if (cleaned[i] === '}') depth--;
-      if (depth === 0) return cleaned.substring(firstBrace, i + 1);
+    if (character === '"') inString = true;
+    else if (character === '{') closingDelimiters.push('}');
+    else if (character === '[') closingDelimiters.push(']');
+    else if (character === '}' || character === ']') {
+      if (closingDelimiters.pop() !== character) return cleaned;
+      if (closingDelimiters.length === 0) return cleaned.slice(start, i + 1);
     }
   }
 

--- a/src/lib/interviewAnalysis.ts
+++ b/src/lib/interviewAnalysis.ts
@@ -17,13 +17,13 @@ import {
   getInterviewChecked,
   recordInterviewAnalysisFailure,
 } from './kv';
-import { validateProvenance } from './synthesisReceipt';
+import { validateProvenance } from './synthesisProvenance';
 import { resolveEvidenceRef } from './evidence';
 import { createRequestId, logRequestEvent, logRequestFailure } from './requestLog';
 import type { InterviewAnalysisFailureKind, StoredStudy } from '@/types';
 
 export type RunAnalysisOutcome =
-  | { status: 'complete' | 'already-complete' | 'busy' | 'not-found' }
+  | { status: 'complete' | 'already-complete' | 'busy' | 'not-found' | 'unavailable' }
   | { status: 'failed'; failureKind: InterviewAnalysisFailureKind };
 
 export async function runInterviewAnalysis(input: {
@@ -40,16 +40,17 @@ export async function runInterviewAnalysis(input: {
   const operation = input.platformAuthority?.participantSessionId ? 'deferred' : 'researcher';
 
   // The `status` field is numeric everywhere in requestLog (route.failure's
-  // HTTP status); 200 here means "the pipeline ran and recorded an outcome
-  // without throwing" — success and a handled failure both count. `reason`
-  // (reused from the existing allowlist) is the only thing that distinguishes
-  // a failure, and it carries no provider text, message, or output.
-  const logOutcome = (reason?: 'provider-failure' | 'invalid' | 'too-large' | 'unavailable') => {
+  // HTTP status); 200 means a known record outcome, while 503 preserves
+  // storage uncertainty. Neither a reason nor a status carries provider text.
+  const logOutcome = (
+    reason?: 'provider-failure' | 'invalid' | 'too-large' | 'unavailable',
+    status = 200,
+  ) => {
     logRequestEvent({
       event: 'interview.analysis',
       route: '/api/interviews/analyze',
       operation,
-      status: 200,
+      status,
       ...(reason ? { reason } : {}),
     });
   };
@@ -61,16 +62,53 @@ export async function runInterviewAnalysis(input: {
     const outcome: RunAnalysisOutcome =
       claim.status === 'already-complete' ? { status: 'already-complete' }
       : claim.status === 'not-found' ? { status: 'not-found' }
+      : claim.status === 'unavailable' ? { status: 'unavailable' }
       : { status: 'busy' };
-    logOutcome();
+    logOutcome(outcome.status === 'unavailable' ? 'unavailable' : undefined,
+      outcome.status === 'unavailable' ? 503 : 200);
     return outcome;
   }
   const claimId = claim.claimId;
 
+  // Failure recording is also a conditional write: another run may have
+  // completed, replaced this claim, or deleted the record. Report a failure
+  // only when its write was acknowledged. An outage remains retryable even
+  // when a best-effort storage-failure marker succeeds.
+  const recordFailure = async (
+    failureKind: InterviewAnalysisFailureKind,
+    reason: 'provider-failure' | 'invalid' | 'too-large' | 'unavailable',
+  ): Promise<RunAnalysisOutcome> => {
+    const recorded = await recordInterviewAnalysisFailure(interviewId, claimId, failureKind, kvClient);
+    switch (recorded.status) {
+      case 'written':
+        if (failureKind === 'storage') {
+          logOutcome('unavailable', 503);
+          return { status: 'unavailable' };
+        }
+        logOutcome(reason);
+        return { status: 'failed', failureKind };
+      case 'already-complete':
+        logOutcome();
+        return { status: 'already-complete' };
+      case 'stale':
+        logOutcome();
+        return { status: 'busy' };
+      case 'not-found':
+        logOutcome();
+        return { status: 'not-found' };
+      default:
+        logOutcome('unavailable', 503);
+        return { status: 'unavailable' };
+    }
+  };
+
   // 2. A record that vanished between claim and read is `not-found` — the
   // study or interview was deleted concurrently; there is nothing to write to.
   const loaded = await getInterviewChecked(interviewId, kvClient);
-  if (loaded.status !== 'found') {
+  if (loaded.status === 'unavailable') {
+    return recordFailure('storage', 'unavailable');
+  }
+  if (loaded.status === 'not-found') {
     logOutcome();
     return { status: 'not-found' };
   }
@@ -91,9 +129,7 @@ export async function runInterviewAnalysis(input: {
     // logRequestFailure is the only thing that ever sees the caught error;
     // never the stored record, never a response body, never a screen.
     logRequestFailure({ event: 'route.failure', route: '/api/interviews/analyze', operation }, error);
-    await recordInterviewAnalysisFailure(interviewId, claimId, 'provider', kvClient);
-    logOutcome('provider-failure');
-    return { status: 'failed', failureKind: 'provider' };
+    return recordFailure('provider', 'provider-failure');
   }
 
   // 4. A result not naming the provider and model that actually ran is not
@@ -105,9 +141,7 @@ export async function runInterviewAnalysis(input: {
     routedProvider: result.execution.routedProvider,
   });
   if (!provenance) {
-    await recordInterviewAnalysisFailure(interviewId, claimId, 'invalid-output', kvClient);
-    logOutcome('invalid');
-    return { status: 'failed', failureKind: 'invalid-output' };
+    return recordFailure('invalid-output', 'invalid');
   }
 
   // 5. Attach the result.
@@ -150,13 +184,9 @@ export async function runInterviewAnalysis(input: {
       logOutcome();
       return { status: 'not-found' };
     case 'too-large':
-      await recordInterviewAnalysisFailure(interviewId, claimId, 'too-large', kvClient);
-      logOutcome('too-large');
-      return { status: 'failed', failureKind: 'too-large' };
+      return recordFailure('too-large', 'too-large');
     case 'unavailable':
     default:
-      await recordInterviewAnalysisFailure(interviewId, claimId, 'storage', kvClient);
-      logOutcome('unavailable');
-      return { status: 'failed', failureKind: 'storage' };
+      return recordFailure('storage', 'unavailable');
   }
 }

--- a/src/lib/kv.ts
+++ b/src/lib/kv.ts
@@ -20,7 +20,7 @@ import { parseStudyCasResult } from './wire/studyCas';
 import type { PersistRatePlanRow } from './rateLimit';
 import { logRequestFailure } from './requestLog';
 import { STUDY_JSON_LUA } from './studyJsonLua';
-import type { SynthesisProvenance } from './synthesisReceipt';
+import type { SynthesisProvenance } from './synthesisProvenance';
 
 // Key prefixes for organizing data
 const INTERVIEW_PREFIX = 'interview:';
@@ -674,7 +674,8 @@ export type AttachAnalysisResult =
  * KEYS[1] interview:<id>   ARGV[1] op 'claim'|'complete'|'fail'
  * ARGV[2] interviewId      ARGV[3] nowMs   ARGV[4] leaseMs
  * ARGV[5] claimId (claim: the new token; complete/fail: the token held)
- * ARGV[6] the replacement `analysis` member as JSON text
+ * ARGV[6] the replacement `analysis` metadata as JSON text; the script owns
+ *   attempts and preserves the running attempt's lastAttemptAt on completion
  * ARGV[7] complete only: the `synthesis` member as JSON text; '' otherwise
  * ARGV[8] complete only: a flat JSON object of the provenance members
  *   (aiProvider/aiModel/requestedAiModel/routedProvider) to patch alongside
@@ -695,6 +696,9 @@ if not interview then return {'oi:analysis-notfound'} end
 if interview.status ~= 'completed' or interview.id ~= ARGV[2] then
   return {'oi:analysis-notfound'}
 end
+if type(interview.studyId) ~= 'string' or type(interview.createdAt) ~= 'number' or type(interview.completedAt) ~= 'number' then
+  return {'oi:analysis-unavailable'}
+end
 
 local op = ARGV[1]
 local nowMs = tonumber(ARGV[3])
@@ -713,10 +717,15 @@ end
 local effectiveStatus
 local effectiveClaimId
 local effectiveClaimedAt
+local attempts = 0
 if state then
   effectiveStatus = state.status
   effectiveClaimId = state.claimId
   effectiveClaimedAt = tonumber(state.claimedAt)
+  attempts = state.attempts
+  if type(attempts) ~= 'number' or attempts < 0 or attempts > 9007199254740991 or attempts ~= math.floor(attempts) then
+    return {'oi:analysis-unavailable'}
+  end
 else
   local synthesisRaw = json_object_value(body, 'synthesis')
   effectiveStatus = (synthesisRaw and synthesisRaw ~= 'null') and 'complete' or 'pending'
@@ -727,9 +736,12 @@ if op == 'claim' then
   if effectiveStatus == 'running' and effectiveClaimedAt and (nowMs - effectiveClaimedAt) < leaseMs then
     return {'oi:analysis-busy'}
   end
-  local patched = patch_json_object(body, {{'analysis', ARGV[6]}})
+  if attempts >= 9007199254740991 then return {'oi:analysis-unavailable'} end
+  local nextAttempts = string.format('%.0f', attempts + 1)
+  local nextAnalysis = patch_json_object(ARGV[6], {{'attempts', nextAttempts}})
+  local patched = patch_json_object(body, {{'analysis', nextAnalysis}})
   redis.call('SET', KEYS[1], 'oi:interview:' .. patched)
-  return {'oi:analysis-claimed', claimId}
+  return {'oi:analysis-claimed', 'oi:count:' .. nextAttempts}
 end
 
 if effectiveStatus == 'complete' then return {'oi:analysis-done'} end
@@ -737,8 +749,17 @@ if effectiveStatus ~= 'running' or effectiveClaimId ~= claimId then
   return {'oi:analysis-stale'}
 end
 
+-- Counters and the attempt-start timestamp come from this claimed record,
+-- never a GET taken before a contender's claim or failure became visible.
+local lastAttemptAt = json_object_value(analysisRaw, 'lastAttemptAt')
+if not lastAttemptAt then return {'oi:analysis-unavailable'} end
+local nextAnalysis = patch_json_object(ARGV[6], {
+  {'attempts', string.format('%.0f', attempts)},
+  {'lastAttemptAt', lastAttemptAt}
+})
+
 if op == 'complete' then
-  local updates = {{'analysis', ARGV[6]}, {'synthesis', ARGV[7]}}
+  local updates = {{'analysis', nextAnalysis}, {'synthesis', ARGV[7]}}
   for _, member in ipairs(json_object_members(ARGV[8])) do
     updates[#updates + 1] = {member.key, member.value}
   end
@@ -748,7 +769,7 @@ if op == 'complete' then
 end
 
 if op == 'fail' then
-  local patched = patch_json_object(body, {{'analysis', ARGV[6]}})
+  local patched = patch_json_object(body, {{'analysis', nextAnalysis}})
   redis.call('SET', KEYS[1], 'oi:interview:' .. patched)
   return {'oi:analysis-recorded'}
 end
@@ -781,15 +802,9 @@ export async function claimInterviewAnalysis(
   nowMs: number = Date.now(),
 ): Promise<ClaimAnalysisResult> {
   if (!INTERVIEW_ID_TOKEN.test(interviewId)) return { status: 'unavailable' };
-  const loaded = await getInterviewChecked(interviewId, client);
-  if (loaded.status === 'unavailable') return { status: 'unavailable' };
-  if (loaded.status === 'not-found') return { status: 'not-found' };
-
-  const priorAttempts = loaded.interview.analysis?.attempts ?? 0;
   const claimId = randomUUID();
   const analysisMember = JSON.stringify({
     status: 'running',
-    attempts: priorAttempts + 1,
     lastAttemptAt: nowMs,
     claimId,
     claimedAt: nowMs,
@@ -800,7 +815,7 @@ export async function claimInterviewAnalysis(
     if (!outcome) return { status: 'unavailable' };
     switch (outcome.outcome) {
       case 'claimed':
-        return { status: 'claimed', claimId: outcome.value, attempts: priorAttempts + 1 };
+        return { status: 'claimed', claimId, attempts: outcome.attempts };
       case 'busy':
         return { status: 'busy' };
       case 'done':
@@ -841,17 +856,8 @@ export async function attachInterviewAnalysis(
   });
 
   try {
-    // Read-modify-write requires the current attempts count; a claim just
-    // ran so the record exists, but a vanished record between claim and
-    // attach is a legitimate 'not-found', not a crash.
-    const loaded = await getInterviewChecked(input.interviewId, client);
-    if (loaded.status === 'unavailable') return { status: 'unavailable' };
-    if (loaded.status === 'not-found') return { status: 'not-found' };
-    const attempts = loaded.interview.analysis?.attempts ?? 1;
     const analysisMember = JSON.stringify({
       status: 'complete',
-      attempts,
-      lastAttemptAt: nowMs,
       studyRevision: input.studyRevision,
     });
     const outcome = await evalAttachAnalysis(
@@ -885,14 +891,8 @@ export async function recordInterviewAnalysisFailure(
   if (!INTERVIEW_ID_TOKEN.test(interviewId)) return { status: 'unavailable' };
   const nowMs = Date.now();
   try {
-    const loaded = await getInterviewChecked(interviewId, client);
-    if (loaded.status === 'unavailable') return { status: 'unavailable' };
-    if (loaded.status === 'not-found') return { status: 'not-found' };
-    const attempts = loaded.interview.analysis?.attempts ?? 1;
     const analysisMember = JSON.stringify({
       status: 'failed',
-      attempts,
-      lastAttemptAt: nowMs,
       failureKind,
     });
     const outcome = await evalAttachAnalysis('fail', interviewId, claimId, analysisMember, '', '{}', client, nowMs);

--- a/src/lib/prompts/synthesis.ts
+++ b/src/lib/prompts/synthesis.ts
@@ -100,7 +100,7 @@ export const buildSynthesisPrompt = (
 ): string => {
   // Format transcript. Numbering runs over every element of `history`, 1-based,
   // regardless of role, because that is the array the researcher's `t. N`
-  // coordinate counts and the synthesis receipt binds.
+  // coordinate and evidence references address.
   const interviewText = history
     .map((m, i) => `TURN ${i + 1} · ${m.role === 'user' ? 'PARTICIPANT' : 'INTERVIEWER'}: ${m.content}`)
     .join('\n\n');

--- a/src/lib/providers/shared.ts
+++ b/src/lib/providers/shared.ts
@@ -1,6 +1,7 @@
 import type { ProviderExecution, ProviderResult } from '../ai';
 import type { AIProviderType, AggregateSynthesisProviderPayload, AggregateSynthesisResult, StudyConfig } from '@/types';
 import type { FollowupStudy } from '../providerValidation';
+import { ProviderFailure } from '../providerErrors';
 
 export const GREETING_DEADLINE_MS = 30_000;
 export const INTERVIEW_DEADLINE_MS = 60_000;
@@ -21,10 +22,14 @@ export function execution(
   responseModel?: string | null,
   routedProvider?: string | null,
 ): ProviderExecution {
+  const model = typeof responseModel === 'string' ? responseModel.trim() : '';
+  if (!model) {
+    throw new ProviderFailure('invalid-response', `${provider} response omitted its resolved model`);
+  }
   return {
     provider,
     requestedModel,
-    model: responseModel?.trim() || requestedModel,
+    model,
     ...(routedProvider?.trim() ? { routedProvider: routedProvider.trim() } : {}),
   };
 }

--- a/src/lib/synthesisProvenance.ts
+++ b/src/lib/synthesisProvenance.ts
@@ -3,18 +3,9 @@ import { isKnownProviderModel, PROVIDER_MODELS } from './providerRegistry';
 import { gatewayRouteForProvider, isGatewayProvider, toGatewayModelId } from './aiTransport';
 
 /**
- * Shared provenance validation. Originally paired with a per-interview
- * signing/verification receipt that bound a browser-carried synthesis to the
- * study, revision and participant session before the save route would accept
- * it (slice K). Slice P removed that boundary entirely: `runInterviewAnalysis`
- * calls the provider and writes the result in the same function, holding the
- * canonical study it loaded itself, so no synthesis ever crosses a trust
- * boundary that needs a signature to close. What remains is the honesty
- * check every provenance-carrying record still needs: a result that does not
- * name a known provider and the model that actually produced it is not
- * storable (AGENTS.md). `validateProvenance`/`aggregateProvenance` are called
- * by `runInterviewAnalysis`, `synthesis/aggregate/route.ts`, and
- * `generate-followup/route.ts`.
+ * Shared validation for server-generated interview, aggregate, and follow-up
+ * provenance. Stored results must name a known requested provider/model and
+ * the model that actually produced the output, including its route when used.
  */
 export interface SynthesisProvenance {
   aiProvider: AIProviderType;

--- a/src/lib/wire/parse.ts
+++ b/src/lib/wire/parse.ts
@@ -361,7 +361,7 @@ export function parseReceiptResult(wire: unknown): WireResult<never> {
 
 export type AnalysisWireOutcome =
   | { outcome: 'notfound' | 'busy' | 'done' | 'stale' | 'written' | 'recorded' }
-  | { outcome: 'claimed'; value: string };
+  | { outcome: 'claimed'; attempts: number };
 
 const ANALYSIS_SIMPLE: Record<string, Exclude<AnalysisWireOutcome['outcome'], 'claimed'>> = {
   'oi:analysis-notfound': 'notfound',
@@ -376,7 +376,10 @@ export function parseAnalysisResult(wire: unknown): WireResult<AnalysisWireOutco
   const parsed = parseFamilyWire('analysis', wire);
   if (parsed.status !== 'ok') return parsed;
   const { tag, payload } = parsed.value;
-  if (tag === 'oi:analysis-claimed') return ok({ outcome: 'claimed', value: payload as string });
+  if (tag === 'oi:analysis-claimed') {
+    if (typeof payload !== 'number' || payload < 1) return UNAVAILABLE;
+    return ok({ outcome: 'claimed', attempts: payload });
+  }
   const outcome = ANALYSIS_SIMPLE[tag];
   if (!outcome) return UNAVAILABLE;
   return ok({ outcome });

--- a/src/lib/wire/types.ts
+++ b/src/lib/wire/types.ts
@@ -203,7 +203,7 @@ export const FAMILY_TAGS: Record<FamilyName, Readonly<Record<string, WireTagSpec
     'oi:analysis-stale': { arity: 1 },
     'oi:analysis-written': { arity: 1 },
     'oi:analysis-recorded': { arity: 1 },
-    'oi:analysis-claimed': { arity: 2, payloadKind: 'string' },
+    'oi:analysis-claimed': { arity: 2, payloadKind: 'count' },
   },
 };
 

--- a/src/services/analysisApi.ts
+++ b/src/services/analysisApi.ts
@@ -1,0 +1,51 @@
+import type { InterviewAnalysisFailureKind } from '@/types';
+
+export type InterviewAnalysisOutcome =
+  | { status: 'complete' | 'already-complete' | 'busy' }
+  | { status: 'failed'; failureKind: InterviewAnalysisFailureKind };
+
+export type AnalyzeInterviewResult =
+  | { ok: true; outcome: InterviewAnalysisOutcome }
+  | { ok: false; error: string; kind: 'request' | 'pending' };
+
+const FAILURE_KINDS = new Set<InterviewAnalysisFailureKind>([
+  'provider', 'invalid-output', 'too-large', 'timeout', 'storage',
+]);
+
+/** Only stored analysis outcomes cross this boundary; request failures are separate. */
+export async function analyzeInterview(interviewId: string, studyId: string): Promise<AnalyzeInterviewResult> {
+  try {
+    const response = await fetch(
+      `/api/interviews/${encodeURIComponent(interviewId)}/analyze?studyId=${encodeURIComponent(studyId)}`,
+      { method: 'POST' },
+    );
+    const data: unknown = await response.json().catch(() => null);
+    const body = data && typeof data === 'object' ? data as Record<string, unknown> : null;
+
+    if (!response.ok) {
+      if (response.status === 409 && body?.code === 'STUDY_OPERATION_PENDING') {
+        return { ok: false, kind: 'pending', error: 'A study operation is already in progress. Try again after it finishes.' };
+      }
+      if (response.status === 429) {
+        return { ok: false, kind: 'request', error: 'The analysis request limit has been reached. Wait before trying again.' };
+      }
+      if (response.status === 503) {
+        return { ok: false, kind: 'request', error: 'Analysis is temporarily unavailable. Please try again.' };
+      }
+      if (response.status === 401 || response.status === 403) {
+        return { ok: false, kind: 'request', error: 'Analysis could not be authorized. Reload the page and sign in if needed.' };
+      }
+      return { ok: false, kind: 'request', error: 'The analysis request could not be completed. Please try again.' };
+    }
+
+    if (body?.status === 'complete' || body?.status === 'already-complete' || body?.status === 'busy') {
+      return { ok: true, outcome: { status: body.status } };
+    }
+    if (body?.status === 'failed' && FAILURE_KINDS.has(body.failureKind as InterviewAnalysisFailureKind)) {
+      return { ok: true, outcome: { status: 'failed', failureKind: body.failureKind as InterviewAnalysisFailureKind } };
+    }
+    return { ok: false, kind: 'request', error: 'The analysis result could not be confirmed. Reload the page before trying again.' };
+  } catch {
+    return { ok: false, kind: 'request', error: 'The analysis request could not reach the server. Check your connection and try again.' };
+  }
+}

--- a/tests/e2e/research-workflow.spec.ts
+++ b/tests/e2e/research-workflow.spec.ts
@@ -60,10 +60,10 @@ test('researcher creates a study; participants finalize; researcher reads, downl
 
     // Refresh is a realistic retry surface: it must retain success without
     // creating a duplicate interview or invoking the provider again.
-    const saveCallsBefore = workflow.calls.length;
+    await expect.poll(() => workflow.calls.filter(call => call.operation === 'synthesis').length).toBe(1);
     await participant.reload();
     await expect(participant.getByRole('heading', { name: 'Thank you' })).toBeVisible();
-    expect(workflow.calls.length).toBeGreaterThanOrEqual(saveCallsBefore);
+    expect(workflow.calls.filter(call => call.operation === 'synthesis')).toHaveLength(1);
     await context.close();
   }
 
@@ -92,6 +92,19 @@ test('researcher creates a study; participants finalize; researcher reads, downl
   await page.setViewportSize({ width: 1280, height: 720 });
   await page.getByRole('tab', { name: 'Interviews', exact: true }).click();
   await expect(page.getByRole('button', { name: /View interview \d/ })).toHaveCount(2);
+
+  // A failed batch request must retain the register, including on a phone,
+  // rather than reloading into an empty state during the same outage.
+  await page.setViewportSize({ width: 375, height: 812 });
+  workflow.storageOffline = true;
+  await page.getByRole('button', { name: /^Analyze \d+ pending$/ }).click();
+  await expect(page.getByRole('alert').filter({ hasText: 'Analysis batch stopped' })).toBeVisible();
+  await expect(page.getByRole('button', { name: /View interview \d/ })).toHaveCount(2);
+  expect(await page.evaluate(() => document.documentElement.scrollWidth <= window.innerWidth)).toBe(true);
+  await page.screenshot({ path: testInfo.outputPath('analysis-batch-recovery-mobile.png'), fullPage: true });
+  workflow.storageOffline = false;
+  await page.setViewportSize({ width: 1280, height: 720 });
+
   await page.getByRole('button', { name: 'View interview 1', exact: true }).click();
   await expect(page.getByText(ANSWER, { exact: true })).toBeVisible();
   const transcript = await downloadText(page, 'Download transcript');
@@ -117,12 +130,27 @@ test('researcher creates a study; participants finalize; researcher reads, downl
   // Participant one's interview: the deferred analysis failed. The Analysis
   // tab is honest about that — pending (the deferred run has not landed yet)
   // or failed (it already has) are both correct, depending on timing.
+  // Standalone detail links also work without a studyId query. Recovery must
+  // use the study id from the interview loaded by the server.
+  await page.goto(new URL(page.url()).pathname);
   await page.getByRole('tab', { name: 'Analysis', exact: true }).click();
   const runAnalysis = page.getByRole('button', { name: 'Run analysis', exact: true });
   await expect(runAnalysis).toBeVisible();
   await expect(page.getByText(/^Analysis (pending|failed)$/)).toBeVisible();
+
+  // A storage refusal is visible and leaves the transcript available. Retry
+  // goes through the real analysis API after the synthetic outage is lifted.
+  await page.setViewportSize({ width: 375, height: 812 });
+  workflow.storageOffline = true;
+  await runAnalysis.click();
+  await expect(page.getByRole('alert').filter({ hasText: 'Analysis is temporarily unavailable. Please try again.' })).toBeVisible();
+  expect(await page.evaluate(() => document.documentElement.scrollWidth <= window.innerWidth)).toBe(true);
+  await page.screenshot({ path: testInfo.outputPath('analysis-recovery-mobile.png'), fullPage: true });
+  workflow.storageOffline = false;
   await runAnalysis.click();
   await expect(page.getByText(INSIGHT, { exact: true }).first()).toBeVisible();
+  await expect(page.getByRole('tabpanel', { name: 'Analysis' }).getByRole('alert')).toHaveCount(0);
+  await page.setViewportSize({ width: 1280, height: 720 });
   // The concrete consequence of feat/synthesis-uses-study-model: the
   // analysis footer names the study's own model, not a fixed override.
   const footer = page.getByText(/^Conducted by/);

--- a/tests/e2e/workflow-fixture.ts
+++ b/tests/e2e/workflow-fixture.ts
@@ -124,7 +124,7 @@ export const test = nextTest.extend<{ workflow: Workflow }>({
       if (operation === 'synthesis' && workflow.failNextSynthesis) {
         workflow.failNextSynthesis = false;
         // A terminal 400 prevents the provider SDK's transport retry from hiding
-        // the user-facing retry. The user must explicitly retry finalization.
+        // researcher recovery. The participant's save remains successful.
         return Response.json({ error: { message: 'Synthetic unavailable synthesis model', type: 'invalid_request_error' } }, { status: 400 });
       }
       const text = operation === 'greeting' ? GREETING : JSON.stringify(

--- a/tests/integration/redis.crashCuts.test.ts
+++ b/tests/integration/redis.crashCuts.test.ts
@@ -4,6 +4,7 @@
 import { randomBytes, randomUUID } from 'node:crypto';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import type { RedisNodeAdapter } from '@/lib/redisNodeAdapter';
+import type { RedisPort } from '@/lib/redisPort';
 import { computeRedisBrand } from '@/lib/redisNodeAdapter';
 import { buildSchemaLineageValue } from '@/lib/platformSchema';
 import {
@@ -24,16 +25,20 @@ import {
 } from '@/lib/platformDb';
 import {
   attachInterviewAnalysis,
+  ANALYSIS_CLAIM_LEASE_MS,
   claimInterviewAnalysis,
   CREATE_STUDY_SCRIPT,
   DELETE_EMPTY_STUDY_SCRIPT,
   createStudyAtomic,
   deleteStudy,
   encodeMutationGuard,
+  encodeInterviewValue,
+  getInterviewChecked,
   getStudyAggregateChecked,
   persistCompletedInterview,
   persistCompletedInterviewFinish,
   persistCompletedInterviewP1,
+  recordInterviewAnalysisFailure,
   replaceStudyConfigAtomic,
   saveStudyAggregate,
   setStudyLinksEnabled,
@@ -946,6 +951,103 @@ describe('transport response-loss and undecodable-after-commit', () => {
 });
 
 describe('slice P: interview analysis attach preserves untouched JSON types', () => {
+  it('counts a delayed contender after intervening failures without overwriting its attempt-start time', async () => {
+    const interview = makeStoredInterview({ id: `interview-${uuid()}` });
+    await redis.set(`interview:${interview.id}`, encodeInterviewValue(interview));
+    const waiting = Promise.withResolvers<void>();
+    const release = Promise.withResolvers<void>();
+    const delayedClient = {
+      get: redis.get.bind(redis),
+      eval: async (...args: Parameters<RedisPort['eval']>) => {
+        waiting.resolve();
+        await release.promise;
+        return redis.eval(...args);
+      },
+    } as RedisPort;
+
+    // Before the fix this request GETs attempts=0, then queues its EVAL
+    // behind two complete claim/failure cycles and writes attempts=1 again.
+    const delayedClaim = claimInterviewAnalysis(interview.id, delayedClient, NOW);
+    await waiting.promise;
+    try {
+      for (let attempt = 1; attempt <= 2; attempt += 1) {
+        const claim = await claimInterviewAnalysis(interview.id, redis, NOW + attempt);
+        expect(claim).toMatchObject({ status: 'claimed', attempts: attempt });
+        if (claim.status !== 'claimed') throw new Error('Claim failed');
+        expect(await recordInterviewAnalysisFailure(interview.id, claim.claimId, 'provider', redis))
+          .toEqual({ status: 'written' });
+        const failed = await getInterviewChecked(interview.id, redis);
+        expect(failed.status === 'found' && failed.interview.analysis).toMatchObject({
+          status: 'failed', attempts: attempt, lastAttemptAt: NOW + attempt,
+        });
+      }
+    } finally {
+      release.resolve();
+    }
+
+    const claim = await delayedClaim;
+    expect(claim).toMatchObject({ status: 'claimed', attempts: 3 });
+    if (claim.status !== 'claimed') throw new Error('Delayed claim failed');
+    expect(await attachInterviewAnalysis({
+      interviewId: interview.id,
+      claimId: claim.claimId,
+      synthesis: {
+        statedPreferences: [], revealedPreferences: [], themes: [],
+        contradictions: [], keyInsights: [], bottomLine: 'Saved analysis',
+      },
+      provenance: { aiProvider: 'gemini', aiModel: 'gemini-3.7-flash', requestedAiModel: 'gemini-3.7-flash' },
+      studyRevision: 2,
+    }, redis)).toEqual({ status: 'written' });
+    const completed = await getInterviewChecked(interview.id, redis);
+    expect(completed.status === 'found' && completed.interview.analysis).toMatchObject({
+      status: 'complete', attempts: 3, lastAttemptAt: NOW, studyRevision: 2,
+    });
+  });
+
+  it('admits one racing claim and fences its writes after a lease takeover', async () => {
+    const interview = makeStoredInterview({ id: `interview-${uuid()}` });
+    await redis.set(`interview:${interview.id}`, encodeInterviewValue(interview));
+    const racing = await Promise.all([
+      claimInterviewAnalysis(interview.id, redis, NOW),
+      claimInterviewAnalysis(interview.id, redis, NOW),
+    ]);
+    expect(racing.map(claim => claim.status).sort()).toEqual(['busy', 'claimed']);
+    const first = racing.find(claim => claim.status === 'claimed');
+    if (!first || first.status !== 'claimed') throw new Error('Claim failed');
+    const takeover = await claimInterviewAnalysis(interview.id, redis, NOW + ANALYSIS_CLAIM_LEASE_MS);
+    expect(takeover).toMatchObject({ status: 'claimed', attempts: 2 });
+    if (takeover.status !== 'claimed') throw new Error('Takeover failed');
+    expect(await attachInterviewAnalysis({
+      interviewId: interview.id,
+      claimId: first.claimId,
+      synthesis: {
+        statedPreferences: [], revealedPreferences: [], themes: [],
+        contradictions: [], keyInsights: [], bottomLine: 'Stale analysis',
+      },
+      provenance: { aiProvider: 'gemini', aiModel: 'gemini-3.7-flash', requestedAiModel: 'gemini-3.7-flash' },
+      studyRevision: 1,
+    }, redis)).toEqual({ status: 'stale' });
+    expect(await recordInterviewAnalysisFailure(interview.id, first.claimId, 'provider', redis))
+      .toEqual({ status: 'stale' });
+    expect(await recordInterviewAnalysisFailure(interview.id, takeover.claimId, 'provider', redis))
+      .toEqual({ status: 'written' });
+    const failed = await getInterviewChecked(interview.id, redis);
+    expect(failed.status === 'found' && failed.interview.analysis).toMatchObject({
+      status: 'failed', attempts: 2, lastAttemptAt: NOW + ANALYSIS_CLAIM_LEASE_MS,
+    });
+  });
+
+  it.each([-1, 1.5, '2', Number.MAX_SAFE_INTEGER])('refuses an invalid or exhausted attempt counter (%s) without changing the record', async (attempts) => {
+    const interview = makeStoredInterview({ id: `interview-${uuid()}` });
+    const encoded = `oi:interview:${JSON.stringify({
+      ...interview,
+      analysis: { status: 'pending', attempts, lastAttemptAt: NOW },
+    })}`;
+    await redis.set(`interview:${interview.id}`, encoded);
+    expect(await claimInterviewAnalysis(interview.id, redis, NOW)).toEqual({ status: 'unavailable' });
+    expect(await redis.get(`interview:${interview.id}`)).toBe(encoded);
+  });
+
   it('claim then attach on a record with an empty array and an empty string round-trips both byte-identically', async () => {
     const studyId = uuid();
     const config = makeStudyConfig({ id: studyId, aiProvider: 'gemini', aiModel: 'gemini-3.7-flash' });

--- a/tests/unit/InterviewDetail.analysis.test.tsx
+++ b/tests/unit/InterviewDetail.analysis.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { makeStoredInterview } from '../fixtures/models';
 import type { InterviewAnalysisFailureKind } from '@/types';
@@ -144,5 +144,55 @@ describe('InterviewDetail — four-way analysis state switch', () => {
       expect.objectContaining({ method: 'POST' }),
     );
     expect(await screen.findByText('Now analyzed.')).toBeInTheDocument();
+  });
+
+  it('uses the loaded record study ID when a standalone detail URL has no study query', async () => {
+    storageMock.getInterview.mockResolvedValue(baseInterview);
+    render(
+      <BreadcrumbProvider>
+        <InterviewDetail interviewId={baseInterview.id} />
+      </BreadcrumbProvider>,
+    );
+    await openAnalysisTab();
+    fireEvent.click(screen.getByRole('button', { name: 'Run analysis' }));
+
+    await waitFor(() => expect(storageMock.getInterview).toHaveBeenCalledTimes(2));
+    expect(global.fetch).toHaveBeenCalledWith(
+      '/api/interviews/interview-analysis/analyze?studyId=study-analysis',
+      { method: 'POST' },
+    );
+  });
+
+  it.each<[number, string]>([
+    [429, 'The analysis request limit has been reached. Wait before trying again.'],
+    [503, 'Analysis is temporarily unavailable. Please try again.'],
+  ])('shows a request failure on HTTP %s and leaves the stored analysis state intact', async (status, message) => {
+    storageMock.getInterview.mockResolvedValue(baseInterview);
+    vi.mocked(global.fetch).mockResolvedValue(new Response(JSON.stringify({ error: 'Private upstream error details' }), { status }));
+    renderInterviewDetail();
+    await openAnalysisTab();
+    fireEvent.click(screen.getByRole('button', { name: 'Run analysis' }));
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(message);
+    expect(screen.getByText('Analysis pending')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Run analysis' })).toBeEnabled();
+    expect(screen.queryByText('Private upstream error details')).not.toBeInTheDocument();
+    expect(storageMock.getInterview).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows a network failure and clears it when the researcher retries successfully', async () => {
+    storageMock.getInterview.mockResolvedValue(baseInterview);
+    vi.mocked(global.fetch)
+      .mockRejectedValueOnce(new TypeError('Failed to fetch'))
+      .mockResolvedValueOnce(new Response(JSON.stringify({ status: 'busy' })));
+    renderInterviewDetail();
+    await openAnalysisTab();
+    fireEvent.click(screen.getByRole('button', { name: 'Run analysis' }));
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('Check your connection and try again.');
+    fireEvent.click(screen.getByRole('button', { name: 'Run analysis' }));
+
+    await waitFor(() => expect(storageMock.getInterview).toHaveBeenCalledTimes(2));
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
   });
 });

--- a/tests/unit/StudyDetail.analysisBatch.test.tsx
+++ b/tests/unit/StudyDetail.analysisBatch.test.tsx
@@ -140,4 +140,76 @@ describe('StudyDetail — analysis batch action', () => {
     expect(screen.getByRole('button', { name: 'Analyze All Interviews' })).toBeDisabled();
     expect(screen.getByText('Need at least 2 analyzed interviews to generate aggregate analysis.')).toBeInTheDocument();
   });
+
+  it.each<[number, string]>([
+    [429, 'The analysis request limit has been reached. Wait before trying again.'],
+    [503, 'Analysis is temporarily unavailable. Please try again.'],
+  ])('stops on HTTP %s, explains the failure, and retains the loaded register for retry', async (status, message) => {
+    const pending = [1, 2, 3].map(index => makeStoredInterview({
+      id: `interview-${index}`, studyId: 'study-batch', createdAt: index * 1_000,
+      analysis: { status: 'pending', attempts: 0, lastAttemptAt: 1 },
+    }));
+    storageMock.getStudyInterviews.mockResolvedValueOnce(pending).mockResolvedValue([]);
+    const analyzedIds: string[] = [];
+    vi.stubGlobal('fetch', vi.fn(async (url: string) => {
+      if (!url.includes('/analyze')) return new Response('{}', { status: 404 });
+      analyzedIds.push(url);
+      return analyzedIds.length === 1
+        ? new Response(JSON.stringify({ status: 'complete' }))
+        : new Response(JSON.stringify({ error: 'Private upstream error details' }), { status });
+    }));
+    renderStudyDetail('study-batch');
+    await screen.findByRole('heading', { name: 'Batch Study' });
+    fireEvent.click(screen.getByRole('tab', { name: 'Interviews' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Analyze 3 pending' }));
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(message);
+    expect(await screen.findByRole('button', { name: 'Analyze 3 pending' })).toBeEnabled();
+    expect(analyzedIds).toHaveLength(2);
+    expect(analyzedIds[1]).toContain('interview-2');
+    expect(storageMock.getStudyInterviews).toHaveBeenCalledTimes(1);
+    expect(screen.getByRole('heading', { name: 'Batch Study' })).toBeInTheDocument();
+    expect(screen.queryByText('Private upstream error details')).not.toBeInTheDocument();
+  });
+
+  it('stops and explains a network failure without requesting the next interview', async () => {
+    storageMock.getStudyInterviews.mockResolvedValue([1, 2].map(index => makeStoredInterview({
+      id: `interview-${index}`, studyId: 'study-batch', createdAt: index * 1_000,
+    })));
+    const analyzedIds: string[] = [];
+    vi.stubGlobal('fetch', vi.fn(async (url: string) => {
+      if (!url.includes('/analyze')) return new Response('{}', { status: 404 });
+      analyzedIds.push(url);
+      throw new TypeError('Failed to fetch');
+    }));
+    renderStudyDetail('study-batch');
+    await screen.findByRole('heading', { name: 'Batch Study' });
+    fireEvent.click(screen.getByRole('tab', { name: 'Interviews' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Analyze 2 pending' }));
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('Check your connection and try again.');
+    expect(await screen.findByRole('button', { name: 'Analyze 2 pending' })).toBeEnabled();
+    expect(analyzedIds).toHaveLength(1);
+    expect(storageMock.getStudyInterviews).toHaveBeenCalledTimes(1);
+  });
+
+  it('continues to the next interview after a successfully recorded provider failure', async () => {
+    storageMock.getStudyInterviews.mockResolvedValue([1, 2].map(index => makeStoredInterview({
+      id: `interview-${index}`, studyId: 'study-batch', createdAt: index * 1_000,
+    })));
+    const analyzedIds: string[] = [];
+    vi.stubGlobal('fetch', vi.fn(async (url: string) => {
+      if (!url.includes('/analyze')) return new Response('{}', { status: 404 });
+      analyzedIds.push(url);
+      return new Response(JSON.stringify({ status: 'failed', failureKind: 'provider' }));
+    }));
+    renderStudyDetail('study-batch');
+    await screen.findByRole('heading', { name: 'Batch Study' });
+    fireEvent.click(screen.getByRole('tab', { name: 'Interviews' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Analyze 2 pending' }));
+
+    await waitFor(() => expect(storageMock.getStudyInterviews).toHaveBeenCalledTimes(2));
+    expect(analyzedIds).toHaveLength(2);
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
 });

--- a/tests/unit/aggregateSchema.roundTrip.test.ts
+++ b/tests/unit/aggregateSchema.roundTrip.test.ts
@@ -6,9 +6,7 @@ import { validateResolvedAggregateSynthesis } from '@/lib/providerValidation';
 import { aggregateSynthesisResponseSchema } from '@/lib/providerSchemas';
 import { MAX_AGGREGATE_QUOTE_REFS } from '@/lib/prompts/synthesis';
 
-// Duplicated from synthesisReceipt.ts's canonicalize/digest — those internals
-// are not exported, and this local copy is honest about what it duplicates
-// (see tests/unit/synthesisSchema.roundTrip.test.ts for the same pattern).
+// Compare canonical payloads to detect any content lost during validation.
 function canonicalize(value: unknown): unknown {
   if (Array.isArray(value)) return value.map(canonicalize);
   if (value && typeof value === 'object') {

--- a/tests/unit/analysisApi.test.ts
+++ b/tests/unit/analysisApi.test.ts
@@ -1,0 +1,48 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { analyzeInterview } from '@/services/analysisApi';
+
+afterEach(() => vi.unstubAllGlobals());
+
+describe('researcher analysis response boundary', () => {
+  it('preserves a recorded provider failure as a successful request outcome', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response(JSON.stringify({
+      status: 'failed', failureKind: 'provider', error: 'Private upstream details',
+    })));
+    vi.stubGlobal('fetch', fetchMock);
+
+    expect(await analyzeInterview('interview/id', 'study id')).toEqual({
+      ok: true, outcome: { status: 'failed', failureKind: 'provider' },
+    });
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/interviews/interview%2Fid/analyze?studyId=study%20id',
+      { method: 'POST' },
+    );
+  });
+
+  it.each([
+    {},
+    { status: 'unavailable' },
+    { status: 'failed' },
+    { status: 'failed', failureKind: 'Private upstream details' },
+  ])('refuses an unrecognized 200 response without forwarding its contents: %j', async body => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(JSON.stringify(body))));
+
+    expect(await analyzeInterview('interview-1', 'study-1')).toEqual({
+      ok: false,
+      kind: 'request',
+      error: 'The analysis result could not be confirmed. Reload the page before trying again.',
+    });
+  });
+
+  it('preserves the pending-operation classification without forwarding server error text', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(JSON.stringify({
+      code: 'STUDY_OPERATION_PENDING', error: 'Private server details',
+    }), { status: 409 })));
+
+    expect(await analyzeInterview('interview-1', 'study-1')).toEqual({
+      ok: false,
+      kind: 'pending',
+      error: 'A study operation is already in progress. Try again after it finishes.',
+    });
+  });
+});

--- a/tests/unit/api.aggregate.citations.test.ts
+++ b/tests/unit/api.aggregate.citations.test.ts
@@ -43,14 +43,14 @@ vi.mock('@/lib/providers', async (importOriginal) => {
 const platformRateLimitMock = vi.hoisted(() => ({ hostedAiRateLimitResponse: vi.fn() }));
 vi.mock('@/lib/platformAiRateLimit', () => platformRateLimitMock);
 
-const receiptMock = vi.hoisted(() => ({
+const provenanceMock = vi.hoisted(() => ({
   aggregateProvenance: vi.fn(() => ({
     aiProvider: 'gemini',
     aiModel: GEMINI_SYNTHESIS_MODEL,
     requestedAiModel: GEMINI_SYNTHESIS_MODEL,
   })),
 }));
-vi.mock('@/lib/synthesisReceipt', () => receiptMock);
+vi.mock('@/lib/synthesisProvenance', () => provenanceMock);
 
 import { POST } from '@/app/api/synthesis/aggregate/route';
 

--- a/tests/unit/api.aggregate.revision.test.ts
+++ b/tests/unit/api.aggregate.revision.test.ts
@@ -40,14 +40,14 @@ vi.mock('@/lib/providers', async (importOriginal) => {
 const platformRateLimitMock = vi.hoisted(() => ({ hostedAiRateLimitResponse: vi.fn() }));
 vi.mock('@/lib/platformAiRateLimit', () => platformRateLimitMock);
 
-const receiptMock = vi.hoisted(() => ({
+const provenanceMock = vi.hoisted(() => ({
   aggregateProvenance: vi.fn(() => ({
     aiProvider: 'gemini',
     aiModel: 'gemini-served',
     requestedAiModel: 'gemini-requested',
   })),
 }));
-vi.mock('@/lib/synthesisReceipt', () => receiptMock);
+vi.mock('@/lib/synthesisProvenance', () => provenanceMock);
 
 import { POST } from '@/app/api/synthesis/aggregate/route';
 

--- a/tests/unit/api.analyze.authority.test.ts
+++ b/tests/unit/api.analyze.authority.test.ts
@@ -98,7 +98,15 @@ describe('POST /api/interviews/[id]/analyze — tenancy', () => {
     expect(contextMock.getAuthorizedResearcherStudyContext).not.toHaveBeenCalled();
   });
 
-  it('runs the analysis and returns 200 for a same-tenant, authorized request', async () => {
+  it.each([
+    [{ status: 'complete' }, 200, { status: 'complete' }],
+    [{ status: 'failed', failureKind: 'provider' }, 200, { status: 'failed', failureKind: 'provider' }],
+    [{ status: 'busy' }, 200, { status: 'busy' }],
+    [{ status: 'already-complete' }, 200, { status: 'already-complete' }],
+    [{ status: 'unavailable' }, 503, {
+      error: 'Interview storage is temporarily unavailable. Please try again.', retryable: true,
+    }],
+  ])('returns the factual analysis outcome %j as HTTP %i for an authorized request', async (outcome, status, body) => {
     contextMock.getAuthorizedResearcherStudyContext.mockResolvedValue({
       authorized: true,
       context: { kvClient: {}, researcherId: 'researcher-a' },
@@ -112,13 +120,13 @@ describe('POST /api/interviews/[id]/analyze — tenancy', () => {
       ok: true,
       study: { id: 'study-a', revision: 1, config: { aiProvider: 'gemini', aiModel: 'gemini-3.7-flash' } },
     });
-    analysisMock.runInterviewAnalysis.mockResolvedValue({ status: 'complete' });
+    analysisMock.runInterviewAnalysis.mockResolvedValue(outcome);
 
     const { request, params } = makeRequest('interview-in-a', 'study-a');
     const response = await POST(request, { params });
 
-    expect(response.status).toBe(200);
-    await expect(response.json()).resolves.toEqual({ status: 'complete' });
+    expect(response.status).toBe(status);
+    await expect(response.json()).resolves.toEqual(body);
     expect(analysisMock.runInterviewAnalysis).toHaveBeenCalledTimes(1);
   });
 });

--- a/tests/unit/api.followup.provenance.test.ts
+++ b/tests/unit/api.followup.provenance.test.ts
@@ -40,8 +40,8 @@ vi.mock('@/lib/providers', async (importOriginal) => {
 const platformRateLimitMock = vi.hoisted(() => ({ hostedAiRateLimitResponse: vi.fn() }));
 vi.mock('@/lib/platformAiRateLimit', () => platformRateLimitMock);
 
-const receiptMock = vi.hoisted(() => ({ aggregateProvenance: vi.fn() }));
-vi.mock('@/lib/synthesisReceipt', () => receiptMock);
+const provenanceMock = vi.hoisted(() => ({ aggregateProvenance: vi.fn() }));
+vi.mock('@/lib/synthesisProvenance', () => provenanceMock);
 
 import { POST } from '@/app/api/studies/[id]/generate-followup/route';
 
@@ -86,7 +86,7 @@ beforeEach(() => {
     () => contextMock.getRequestContext(),
   );
   platformRateLimitMock.hostedAiRateLimitResponse.mockResolvedValue(null);
-  receiptMock.aggregateProvenance.mockReturnValue({
+  provenanceMock.aggregateProvenance.mockReturnValue({
     aiProvider: 'gemini',
     aiModel: GEMINI_SYNTHESIS_MODEL,
     requestedAiModel: GEMINI_SYNTHESIS_MODEL,
@@ -246,7 +246,7 @@ describe('follow-up synthesis provenance', () => {
   });
 
   it('rejects a stored aggregate whose provenance is incomplete before calling a provider', async () => {
-    receiptMock.aggregateProvenance.mockReturnValueOnce(null);
+    provenanceMock.aggregateProvenance.mockReturnValueOnce(null);
 
     const response = await POST(request(), { params: Promise.resolve({ id: 'study-followup' }) });
 

--- a/tests/unit/interviewAnalysis.idempotent.test.ts
+++ b/tests/unit/interviewAnalysis.idempotent.test.ts
@@ -53,6 +53,7 @@ const baseInput = () => ({
 beforeEach(() => {
   vi.clearAllMocks();
   kvMock.getInterviewChecked.mockResolvedValue({ status: 'found', interview: makeStoredInterview({ id: 'interview-a' }) });
+  kvMock.recordInterviewAnalysisFailure.mockResolvedValue({ status: 'written' });
 });
 
 describe('runInterviewAnalysis: concurrency', () => {
@@ -97,6 +98,28 @@ describe('runInterviewAnalysis: concurrency', () => {
 });
 
 describe('runInterviewAnalysis: failure classification', () => {
+  it('reports an unavailable claim as a storage outage, without a provider call or an invented busy state', async () => {
+    kvMock.claimInterviewAnalysis.mockResolvedValue({ status: 'unavailable' });
+
+    const result = await runInterviewAnalysis(baseInput());
+
+    expect(result).toEqual({ status: 'unavailable' });
+    expect(synthesizeInterview).not.toHaveBeenCalled();
+    expect(kvMock.getInterviewChecked).not.toHaveBeenCalled();
+    expect(kvMock.recordInterviewAnalysisFailure).not.toHaveBeenCalled();
+  });
+
+  it('keeps a post-claim read outage retryable even when its storage-failure marker succeeds', async () => {
+    kvMock.claimInterviewAnalysis.mockResolvedValue({ status: 'claimed', claimId: 'claim-1', attempts: 1 });
+    kvMock.getInterviewChecked.mockResolvedValue({ status: 'unavailable' });
+
+    const result = await runInterviewAnalysis(baseInput());
+
+    expect(result).toEqual({ status: 'unavailable' });
+    expect(synthesizeInterview).not.toHaveBeenCalled();
+    expect(kvMock.recordInterviewAnalysisFailure).toHaveBeenCalledWith('interview-a', 'claim-1', 'storage', {});
+  });
+
   it('a provider throw records failureKind provider, and the thrown value reaches nowhere near the record', async () => {
     kvMock.claimInterviewAnalysis.mockResolvedValue({ status: 'claimed', claimId: 'claim-1', attempts: 1 });
     const secretError = new Error('super secret upstream body: sk-abc123');
@@ -145,5 +168,57 @@ describe('runInterviewAnalysis: failure classification', () => {
 
     expect(result).toEqual({ status: 'not-found' });
     expect(synthesizeInterview).not.toHaveBeenCalled();
+  });
+
+  it('does not report a persisted provider failure when its failure record could not be written', async () => {
+    kvMock.claimInterviewAnalysis.mockResolvedValue({ status: 'claimed', claimId: 'claim-1', attempts: 1 });
+    synthesizeInterview.mockRejectedValue(new Error('synthetic provider failure'));
+    kvMock.recordInterviewAnalysisFailure.mockResolvedValue({ status: 'unavailable' });
+
+    const result = await runInterviewAnalysis(baseInput());
+
+    expect(result).toEqual({ status: 'unavailable' });
+    expect(kvMock.recordInterviewAnalysisFailure).toHaveBeenCalledOnce();
+    expect(kvMock.attachInterviewAnalysis).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['already-complete', 'already-complete'],
+    ['stale', 'busy'],
+    ['not-found', 'not-found'],
+  ] as const)('reports the record outcome %s when failure recording loses its claim', async (recordStatus, expectedStatus) => {
+    kvMock.claimInterviewAnalysis.mockResolvedValue({ status: 'claimed', claimId: 'claim-1', attempts: 1 });
+    synthesizeInterview.mockRejectedValue(new Error('synthetic provider failure'));
+    kvMock.recordInterviewAnalysisFailure.mockResolvedValue({ status: recordStatus });
+
+    const result = await runInterviewAnalysis(baseInput());
+
+    expect(result).toEqual({ status: expectedStatus });
+    expect(kvMock.recordInterviewAnalysisFailure).toHaveBeenCalledOnce();
+  });
+
+  it('recognizes an attach that committed before losing its response instead of reporting a false storage failure', async () => {
+    kvMock.claimInterviewAnalysis.mockResolvedValue({ status: 'claimed', claimId: 'claim-1', attempts: 1 });
+    synthesizeInterview.mockResolvedValue(providerResult());
+    kvMock.attachInterviewAnalysis.mockResolvedValue({ status: 'unavailable' });
+    kvMock.recordInterviewAnalysisFailure.mockResolvedValue({ status: 'already-complete' });
+
+    const result = await runInterviewAnalysis(baseInput());
+
+    expect(result).toEqual({ status: 'already-complete' });
+    expect(synthesizeInterview).toHaveBeenCalledOnce();
+    expect(kvMock.attachInterviewAnalysis).toHaveBeenCalledOnce();
+    expect(kvMock.recordInterviewAnalysisFailure).toHaveBeenCalledWith('interview-a', 'claim-1', 'storage', {});
+  });
+
+  it('keeps an attach outage retryable even when its storage-failure marker succeeds', async () => {
+    kvMock.claimInterviewAnalysis.mockResolvedValue({ status: 'claimed', claimId: 'claim-1', attempts: 1 });
+    synthesizeInterview.mockResolvedValue(providerResult());
+    kvMock.attachInterviewAnalysis.mockResolvedValue({ status: 'unavailable' });
+
+    const result = await runInterviewAnalysis(baseInput());
+
+    expect(result).toEqual({ status: 'unavailable' });
+    expect(kvMock.recordInterviewAnalysisFailure).toHaveBeenCalledWith('interview-a', 'claim-1', 'storage', {});
   });
 });

--- a/tests/unit/kv.analysisAttach.test.ts
+++ b/tests/unit/kv.analysisAttach.test.ts
@@ -24,7 +24,7 @@ function encodedInterview(overrides: Record<string, unknown> = {}) {
 
 describe('kv.analysisAttach: claimInterviewAnalysis', () => {
   it('sends one eval with exactly one key and the claim op', async () => {
-    const evalMock = vi.fn().mockResolvedValue(['oi:analysis-claimed', 'claim-1']);
+    const evalMock = vi.fn().mockResolvedValue(['oi:analysis-claimed', 'oi:count:3']);
     const client = {
       get: vi.fn().mockResolvedValue(encodedInterview()),
       eval: evalMock,
@@ -32,10 +32,8 @@ describe('kv.analysisAttach: claimInterviewAnalysis', () => {
 
     const result = await claimInterviewAnalysis('interview-a', client);
 
-    // The wire's `claimed` payload (the mock's 'claim-1') is what the caller
-    // gets back — the CAS token is authoritative from Redis, not the id the
-    // caller happened to generate for this attempt.
-    expect(result).toEqual({ status: 'claimed', claimId: 'claim-1', attempts: 1 });
+    expect(result).toEqual({ status: 'claimed', claimId: expect.any(String), attempts: 3 });
+    expect(client.get).not.toHaveBeenCalled();
     expect(evalMock).toHaveBeenCalledTimes(1);
     const [, keys, args] = evalMock.mock.calls[0] as [string, string[], string[]];
     expect(keys).toEqual(['interview:interview-a']);
@@ -43,6 +41,7 @@ describe('kv.analysisAttach: claimInterviewAnalysis', () => {
     expect(args[1]).toBe('interview-a');
     expect(typeof args[4]).toBe('string');
     expect(args[4].length).toBeGreaterThan(0);
+    expect(result.status === 'claimed' && result.claimId).toBe(args[4]);
   });
 
   it('maps each documented claim outcome', async () => {
@@ -77,11 +76,12 @@ describe('kv.analysisAttach: claimInterviewAnalysis', () => {
   });
 
   it('reports not-found when the interview does not exist', async () => {
-    const evalMock = vi.fn();
-    const client = { get: vi.fn().mockResolvedValue(null), eval: evalMock } as unknown as RedisPort;
+    const evalMock = vi.fn().mockResolvedValue(['oi:analysis-notfound']);
+    const client = { get: vi.fn(), eval: evalMock } as unknown as RedisPort;
 
     await expect(claimInterviewAnalysis('interview-a', client)).resolves.toEqual({ status: 'not-found' });
-    expect(evalMock).not.toHaveBeenCalled();
+    expect(evalMock).toHaveBeenCalledTimes(1);
+    expect(client.get).not.toHaveBeenCalled();
   });
 });
 
@@ -124,7 +124,9 @@ describe('kv.analysisAttach: attachInterviewAnalysis', () => {
       studyRevision: 1,
     };
 
-    await expect(attachInterviewAnalysis(input, client('oi:analysis-written'))).resolves.toEqual({ status: 'written' });
+    const writtenClient = client('oi:analysis-written');
+    await expect(attachInterviewAnalysis(input, writtenClient)).resolves.toEqual({ status: 'written' });
+    expect(writtenClient.get).not.toHaveBeenCalled();
     await expect(attachInterviewAnalysis(input, client('oi:analysis-done'))).resolves.toEqual({ status: 'already-complete' });
     await expect(attachInterviewAnalysis(input, client('oi:analysis-stale'))).resolves.toEqual({ status: 'stale' });
     await expect(attachInterviewAnalysis(input, client('oi:analysis-notfound'))).resolves.toEqual({ status: 'not-found' });
@@ -159,5 +161,6 @@ describe('kv.analysisAttach: recordInterviewAnalysisFailure', () => {
 
     await expect(recordInterviewAnalysisFailure('interview-a', 'claim-1', 'provider', client))
       .resolves.toEqual({ status: 'written' });
+    expect(client.get).not.toHaveBeenCalled();
   });
 });

--- a/tests/unit/providers.openai.test.ts
+++ b/tests/unit/providers.openai.test.ts
@@ -137,6 +137,54 @@ describe('OpenAIProvider', () => {
     expect(createMock.mock.calls[1][0].reasoning).toEqual({ effort: 'medium' });
   });
 
+  it.each([
+    'What did you mean by the closing } in your example?',
+    'How did you use [draft] and an opening { in that note?',
+    'You wrote "the } belongs here"; could you explain?',
+    'The path ends with a backslash \\, followed by }; what happened?',
+    'Could you explain the snippet ```json {"role":"editor"} ``` you mentioned?',
+  ])('preserves quoted research content in structured responses: %s', async (message) => {
+    createMock.mockResolvedValue(response(JSON.stringify({ ...interviewJson(), message })));
+    const provider = new OpenAIProvider(undefined, 'sk-test');
+
+    const result = await provider.generateInterviewResponse(
+      [], studyConfig(), null,
+      { questionsAsked: [], total: 1, currentPhase: 'background', isComplete: false },
+      '',
+    );
+
+    expect(result.message).toBe(message);
+  });
+
+  it('removes outer response prose and fences without changing embedded markdown', async () => {
+    const message = 'What did the ```json {"value":"}"} ``` snippet mean to you?';
+    const payload = JSON.stringify({ ...interviewJson(), message });
+    createMock.mockResolvedValue(response(`Here is the response:\n\`\`\`json\n${payload}\n\`\`\`\nEnd of response.`));
+    const provider = new OpenAIProvider(undefined, 'sk-test');
+
+    const result = await provider.generateInterviewResponse(
+      [], studyConfig(), null,
+      { questionsAsked: [], total: 1, currentPhase: 'background', isComplete: false },
+      '',
+    );
+
+    expect(result.message).toBe(message);
+  });
+
+  it.each([
+    JSON.stringify(interviewJson()).slice(0, -1),
+    `${JSON.stringify(interviewJson()).slice(0, -1)}]`,
+  ])('rejects truncated or mismatched structured JSON: %s', async (payload) => {
+    createMock.mockResolvedValue(response(payload));
+    const provider = new OpenAIProvider(undefined, 'sk-test');
+
+    await expect(provider.generateInterviewResponse(
+      [], studyConfig(), null,
+      { questionsAsked: [], total: 1, currentPhase: 'background', isComplete: false },
+      '',
+    )).rejects.toMatchObject({ kind: 'invalid-response' });
+  });
+
   it('sends the study\'s own configured model and returns execution provenance with the served model', async () => {
     createMock.mockResolvedValue(response(JSON.stringify({
       statedPreferences: [],

--- a/tests/unit/providers.provenance.test.ts
+++ b/tests/unit/providers.provenance.test.ts
@@ -1,8 +1,39 @@
 // @vitest-environment node
 
-import { describe, expect, it } from 'vitest';
-import { resolveSynthesisModel } from '@/lib/providers';
+import { describe, expect, it, vi } from 'vitest';
+import { ClaudeProvider, GeminiProvider, OpenAIProvider, OpenRouterProvider, resolveSynthesisModel } from '@/lib/providers';
+import { ProviderFailure } from '@/lib/providerErrors';
+import {
+  type AIProviderType,
+  DEFAULT_CLAUDE_MODEL,
+  DEFAULT_GEMINI_MODEL,
+  DEFAULT_OPENAI_MODEL,
+  DEFAULT_OPENROUTER_MODEL,
+} from '@/types';
 import { makeStudyConfig } from '../fixtures/models';
+
+const providerRequest = vi.hoisted(() => vi.fn());
+
+vi.mock('@google/genai', () => ({
+  GoogleGenAI: class {
+    interactions = { create: providerRequest };
+  },
+}));
+vi.mock('@anthropic-ai/sdk', () => ({
+  default: class {
+    messages = { create: providerRequest };
+  },
+}));
+vi.mock('openai', () => ({
+  default: class {
+    responses = { create: providerRequest };
+  },
+}));
+vi.mock('@openrouter/sdk', () => ({
+  OpenRouter: class {
+    chat = { send: providerRequest };
+  },
+}));
 
 /**
  * Synthesis (per-interview synthesis, aggregate synthesis, and follow-up
@@ -35,5 +66,54 @@ describe('synthesis model resolution', () => {
     expect(() => resolveSynthesisModel(config)).toThrow(
       'Study is missing an explicit AI model required for synthesis',
     );
+  });
+});
+
+function synthesisResponse(provider: AIProviderType, model: string | null | undefined) {
+  const text = JSON.stringify({
+    statedPreferences: [], revealedPreferences: [], themes: [], contradictions: [],
+    keyInsights: ['A synthetic insight.'], bottomLine: 'A synthetic bottom line.',
+  });
+  if (provider === 'claude') return { model, content: [{ type: 'text', text }] };
+  if (provider === 'openrouter') return {
+    model,
+    choices: [{ message: { content: text } }],
+    openrouterMetadata: { attempts: [{ provider: 'OpenAI', status: 200 }] },
+  };
+  return { model, output_text: text };
+}
+
+describe.each([
+  { provider: 'gemini' as const, Provider: GeminiProvider, requestedModel: DEFAULT_GEMINI_MODEL },
+  { provider: 'claude' as const, Provider: ClaudeProvider, requestedModel: DEFAULT_CLAUDE_MODEL },
+  { provider: 'openai' as const, Provider: OpenAIProvider, requestedModel: DEFAULT_OPENAI_MODEL },
+  { provider: 'openrouter' as const, Provider: OpenRouterProvider, requestedModel: DEFAULT_OPENROUTER_MODEL },
+])('$provider served-model provenance', ({ provider, Provider, requestedModel }) => {
+  const config = makeStudyConfig({ aiProvider: provider, aiModel: requestedModel });
+  const behavior = { timePerTopic: {}, messagesPerTopic: {}, topicsExplored: [], contradictions: [] };
+
+  it.each([undefined, null, '', ' \t '])('rejects absent or blank served models (%j)', async (model) => {
+    providerRequest.mockResolvedValue(synthesisResponse(provider, model));
+    const adapter = new Provider(requestedModel, 'synthetic-test-key');
+
+    const result = adapter.synthesizeInterview([], config, behavior, null);
+
+    await expect(result).rejects.toBeInstanceOf(ProviderFailure);
+    await expect(result).rejects.toMatchObject({ kind: 'invalid-response' });
+  });
+
+  it('keeps the dated served snapshot separate from the requested alias', async () => {
+    const servedModel = `${requestedModel}-2026-09-06`;
+    providerRequest.mockResolvedValue(synthesisResponse(provider, ` ${servedModel} `));
+    const adapter = new Provider(requestedModel, 'synthetic-test-key');
+
+    const result = await adapter.synthesizeInterview([], config, behavior, null);
+
+    expect(result.execution).toEqual({
+      provider,
+      requestedModel,
+      model: servedModel,
+      ...(provider === 'openrouter' ? { routedProvider: 'OpenAI' } : {}),
+    });
   });
 });

--- a/tests/unit/synthesisSchema.roundTrip.test.ts
+++ b/tests/unit/synthesisSchema.roundTrip.test.ts
@@ -5,9 +5,7 @@ import { describe, expect, it } from 'vitest';
 import { MAX_EVIDENCE_REFS, validateSynthesisResult } from '@/lib/providerValidation';
 import { synthesisResponseSchema } from '@/lib/providerSchemas';
 
-// Duplicated from synthesisReceipt.ts's canonicalize/digest — those internals
-// are not exported, and this local copy is honest about what it duplicates
-// (see tests/unit/api.save.idempotent.test.ts for the same pattern).
+// Compare canonical payloads to detect any content lost during validation.
 function canonicalize(value: unknown): unknown {
   if (Array.isArray(value)) return value.map(canonicalize);
   if (value && typeof value === 'object') {

--- a/tests/unit/wire.analysis.test.ts
+++ b/tests/unit/wire.analysis.test.ts
@@ -15,10 +15,10 @@ describe('wire.analysis: parseAnalysisResult', () => {
     expect(parseAnalysisResult(['oi:analysis-recorded'])).toEqual({ status: 'ok', value: { outcome: 'recorded' } });
   });
 
-  it('maps the claimed tag with its claimId payload', () => {
-    expect(parseAnalysisResult(['oi:analysis-claimed', 'claim-123'])).toEqual({
+  it('maps the claimed tag with the atomic attempt count', () => {
+    expect(parseAnalysisResult(['oi:analysis-claimed', 'oi:count:3'])).toEqual({
       status: 'ok',
-      value: { outcome: 'claimed', value: 'claim-123' },
+      value: { outcome: 'claimed', attempts: 3 },
     });
   });
 
@@ -35,6 +35,9 @@ describe('wire.analysis: parseAnalysisResult', () => {
     expect(parseAnalysisResult(['oi:analysis-claimed'])).toEqual({ status: 'unavailable' });
     expect(parseAnalysisResult(['oi:analysis-claimed', 5])).toEqual({ status: 'unavailable' });
     expect(parseAnalysisResult(['oi:analysis-claimed', ''])).toEqual({ status: 'unavailable' });
+    for (const malformed of ['claim-123', 'oi:count:0', 'oi:count:-1', 'oi:count:1.5', 'oi:count:9007199254740992']) {
+      expect(parseAnalysisResult(['oi:analysis-claimed', malformed])).toEqual({ status: 'unavailable' });
+    }
     expect(parseAnalysisResult(['oi:analysis-done', 'extra'])).toEqual({ status: 'unavailable' });
     expect(parseAnalysisResult(['oi:analysis-totally-unknown'])).toEqual({ status: 'unavailable' });
   });


### PR DESCRIPTION
Analysis recovery could silently ignore request failures, and delayed concurrent retries could overwrite the attempt count with an older value. Move counting into the existing atomic Redis script, remove redundant transcript reads, and give both researcher screens a shared typed client that displays failures and stops a batch when requests fail. Standalone detail links recover using the fetched interview's study id.

Also preserve quoted delimiters and Markdown in provider JSON, reject missing served-model metadata, and rename the remaining provenance validator to match its current responsibility. Update completion guidance for save-first behavior. No data migration or dependency changes.

Validation completed with Node 24.19.0, a fresh npm install, synthetic provider responses, and disposable Redis:

- Lint, typecheck, and 1,565 unit tests.
- 17 setup tests and demo/direct/Gateway/hosted configuration contracts.
- 30 Redis crash tests and 24 adversarial tests.
- Five browser scenarios through real save/analysis APIs, including outage recovery and 375px checks.
- Direct, Gateway, and hosted production builds; dependency audits clean.
- Independent reviews of the changed storage, API, and UI logic.

See docs/maintenance-review-2026-09-06.md for findings and verification boundaries. Existing undercounted attempt history cannot be reconstructed; future counts are atomic. Live provider availability and quality were not tested.
