### PR TITLE
Distinguish corrupt analysis records from storage outages; add provenance smoke runner

### DIFF
--- a/src/lib/interviewAnalysis.ts
+++ b/src/lib/interviewAnalysis.ts
@@ -43,7 +43,7 @@ export async function runInterviewAnalysis(input: {
   // HTTP status); 200 means a known record outcome, while 503 preserves
   // storage uncertainty. Neither a reason nor a status carries provider text.
   const logOutcome = (
-    reason?: 'provider-failure' | 'invalid' | 'too-large' | 'unavailable',
+    reason?: 'provider-failure' | 'invalid' | 'too-large' | 'unavailable' | 'corrupt-record',
     status = 200,
   ) => {
     logRequestEvent({
@@ -59,6 +59,13 @@ export async function runInterviewAnalysis(input: {
   // immediately, with no provider call.
   const claim = await claimInterviewAnalysis(interviewId, kvClient);
   if (claim.status !== 'claimed') {
+    // A corrupt record is reported to the caller as `unavailable` (the
+    // researcher cannot repair it and the response stays retryable), but the
+    // log reason says which of the two it was.
+    if (claim.status === 'corrupt') {
+      logOutcome('corrupt-record', 503);
+      return { status: 'unavailable' };
+    }
     const outcome: RunAnalysisOutcome =
       claim.status === 'already-complete' ? { status: 'already-complete' }
       : claim.status === 'not-found' ? { status: 'not-found' }
@@ -96,6 +103,9 @@ export async function runInterviewAnalysis(input: {
       case 'not-found':
         logOutcome();
         return { status: 'not-found' };
+      case 'corrupt':
+        logOutcome('corrupt-record', 503);
+        return { status: 'unavailable' };
       default:
         logOutcome('unavailable', 503);
         return { status: 'unavailable' };
@@ -185,6 +195,11 @@ export async function runInterviewAnalysis(input: {
       return { status: 'not-found' };
     case 'too-large':
       return recordFailure('too-large', 'too-large');
+    case 'corrupt':
+      // The record refused this write for a structural reason; a failure
+      // marker would be refused the same way. Return without a second write.
+      logOutcome('corrupt-record', 503);
+      return { status: 'unavailable' };
     case 'unavailable':
     default:
       return recordFailure('storage', 'unavailable');

--- a/src/lib/kv.ts
+++ b/src/lib/kv.ts
@@ -663,12 +663,16 @@ export const MAX_ATTACHED_SYNTHESIS_BYTES = 256_000;
 /** How long one claim holds the record before another run may take over. */
 export const ANALYSIS_CLAIM_LEASE_MS = 180_000;
 
+/** `corrupt`: the stored record exists but its identity members or analysis
+ *  state are not the shape this script owns. Nothing was written; a retry
+ *  cannot succeed until the record is repaired. Distinct from `unavailable`
+ *  (transport or transient) so an operator can tell the two apart in logs. */
 export type ClaimAnalysisResult =
   | { status: 'claimed'; claimId: string; attempts: number }
-  | { status: 'busy' | 'already-complete' | 'not-found' | 'unavailable' };
+  | { status: 'busy' | 'already-complete' | 'not-found' | 'unavailable' | 'corrupt' };
 
 export type AttachAnalysisResult =
-  { status: 'written' | 'already-complete' | 'stale' | 'too-large' | 'not-found' | 'unavailable' };
+  { status: 'written' | 'already-complete' | 'stale' | 'too-large' | 'not-found' | 'unavailable' | 'corrupt' };
 
 /**
  * KEYS[1] interview:<id>   ARGV[1] op 'claim'|'complete'|'fail'
@@ -697,7 +701,7 @@ if interview.status ~= 'completed' or interview.id ~= ARGV[2] then
   return {'oi:analysis-notfound'}
 end
 if type(interview.studyId) ~= 'string' or type(interview.createdAt) ~= 'number' or type(interview.completedAt) ~= 'number' then
-  return {'oi:analysis-unavailable'}
+  return {'oi:analysis-corrupt'}
 end
 
 local op = ARGV[1]
@@ -724,7 +728,7 @@ if state then
   effectiveClaimedAt = tonumber(state.claimedAt)
   attempts = state.attempts
   if type(attempts) ~= 'number' or attempts < 0 or attempts > 9007199254740991 or attempts ~= math.floor(attempts) then
-    return {'oi:analysis-unavailable'}
+    return {'oi:analysis-corrupt'}
   end
 else
   local synthesisRaw = json_object_value(body, 'synthesis')
@@ -752,7 +756,7 @@ end
 -- Counters and the attempt-start timestamp come from this claimed record,
 -- never a GET taken before a contender's claim or failure became visible.
 local lastAttemptAt = json_object_value(analysisRaw, 'lastAttemptAt')
-if not lastAttemptAt then return {'oi:analysis-unavailable'} end
+if not lastAttemptAt then return {'oi:analysis-corrupt'} end
 local nextAnalysis = patch_json_object(ARGV[6], {
   {'attempts', string.format('%.0f', attempts)},
   {'lastAttemptAt', lastAttemptAt}
@@ -822,6 +826,8 @@ export async function claimInterviewAnalysis(
         return { status: 'already-complete' };
       case 'notfound':
         return { status: 'not-found' };
+      case 'corrupt':
+        return { status: 'corrupt' };
       default:
         return { status: 'unavailable' };
     }
@@ -873,6 +879,8 @@ export async function attachInterviewAnalysis(
         return { status: 'stale' };
       case 'notfound':
         return { status: 'not-found' };
+      case 'corrupt':
+        return { status: 'corrupt' };
       default:
         return { status: 'unavailable' };
     }
@@ -906,6 +914,8 @@ export async function recordInterviewAnalysisFailure(
         return { status: 'stale' };
       case 'notfound':
         return { status: 'not-found' };
+      case 'corrupt':
+        return { status: 'corrupt' };
       default:
         return { status: 'unavailable' };
     }

--- a/src/lib/requestLog.ts
+++ b/src/lib/requestLog.ts
@@ -44,6 +44,7 @@ export const REQUEST_LOG_REASON_ALLOWLIST = [
   'invalid',
   'provider-failure',
   'timeout',
+  'corrupt-record',
 ] as const;
 
 export type RequestLogField = (typeof REQUEST_LOG_ALLOWLIST)[number];

--- a/src/lib/wire/parse.ts
+++ b/src/lib/wire/parse.ts
@@ -360,7 +360,7 @@ export function parseReceiptResult(wire: unknown): WireResult<never> {
 }
 
 export type AnalysisWireOutcome =
-  | { outcome: 'notfound' | 'busy' | 'done' | 'stale' | 'written' | 'recorded' }
+  | { outcome: 'notfound' | 'busy' | 'done' | 'stale' | 'written' | 'recorded' | 'corrupt' }
   | { outcome: 'claimed'; attempts: number };
 
 const ANALYSIS_SIMPLE: Record<string, Exclude<AnalysisWireOutcome['outcome'], 'claimed'>> = {
@@ -370,6 +370,7 @@ const ANALYSIS_SIMPLE: Record<string, Exclude<AnalysisWireOutcome['outcome'], 'c
   'oi:analysis-stale': 'stale',
   'oi:analysis-written': 'written',
   'oi:analysis-recorded': 'recorded',
+  'oi:analysis-corrupt': 'corrupt',
 };
 
 export function parseAnalysisResult(wire: unknown): WireResult<AnalysisWireOutcome> {

--- a/src/lib/wire/types.ts
+++ b/src/lib/wire/types.ts
@@ -203,6 +203,7 @@ export const FAMILY_TAGS: Record<FamilyName, Readonly<Record<string, WireTagSpec
     'oi:analysis-stale': { arity: 1 },
     'oi:analysis-written': { arity: 1 },
     'oi:analysis-recorded': { arity: 1 },
+    'oi:analysis-corrupt': { arity: 1 },
     'oi:analysis-claimed': { arity: 2, payloadKind: 'count' },
   },
 };

--- a/tests/integration/redis.crashCuts.test.ts
+++ b/tests/integration/redis.crashCuts.test.ts
@@ -1037,15 +1037,82 @@ describe('slice P: interview analysis attach preserves untouched JSON types', ()
     });
   });
 
-  it.each([-1, 1.5, '2', Number.MAX_SAFE_INTEGER])('refuses an invalid or exhausted attempt counter (%s) without changing the record', async (attempts) => {
+  it.each([-1, 1.5, '2'])('refuses a malformed attempt counter (%s) as corrupt without changing the record', async (attempts) => {
     const interview = makeStoredInterview({ id: `interview-${uuid()}` });
     const encoded = `oi:interview:${JSON.stringify({
       ...interview,
       analysis: { status: 'pending', attempts, lastAttemptAt: NOW },
     })}`;
     await redis.set(`interview:${interview.id}`, encoded);
+    expect(await claimInterviewAnalysis(interview.id, redis, NOW)).toEqual({ status: 'corrupt' });
+    expect(await redis.get(`interview:${interview.id}`)).toBe(encoded);
+  });
+
+  it('refuses a missing attempt counter as corrupt without changing the record', async () => {
+    const interview = makeStoredInterview({ id: `interview-${uuid()}` });
+    const encoded = `oi:interview:${JSON.stringify({
+      ...interview,
+      analysis: { status: 'pending', lastAttemptAt: NOW },
+    })}`;
+    await redis.set(`interview:${interview.id}`, encoded);
+    expect(await claimInterviewAnalysis(interview.id, redis, NOW)).toEqual({ status: 'corrupt' });
+    expect(await redis.get(`interview:${interview.id}`)).toBe(encoded);
+  });
+
+  it('refuses an exhausted attempt counter as unavailable, not corrupt, without changing the record', async () => {
+    const interview = makeStoredInterview({ id: `interview-${uuid()}` });
+    const encoded = `oi:interview:${JSON.stringify({
+      ...interview,
+      analysis: { status: 'pending', attempts: Number.MAX_SAFE_INTEGER, lastAttemptAt: NOW },
+    })}`;
+    await redis.set(`interview:${interview.id}`, encoded);
     expect(await claimInterviewAnalysis(interview.id, redis, NOW)).toEqual({ status: 'unavailable' });
     expect(await redis.get(`interview:${interview.id}`)).toBe(encoded);
+  });
+
+  it('refuses a running claim without an attempt-start time as corrupt on attach and fail, byte-for-byte unchanged', async () => {
+    const interview = makeStoredInterview({ id: `interview-${uuid()}` });
+    const encoded = `oi:interview:${JSON.stringify({
+      ...interview,
+      analysis: { status: 'running', attempts: 1, claimId: 'claim-held', claimedAt: NOW },
+    })}`;
+    await redis.set(`interview:${interview.id}`, encoded);
+    expect(await attachInterviewAnalysis({
+      interviewId: interview.id,
+      claimId: 'claim-held',
+      synthesis: {
+        statedPreferences: [], revealedPreferences: [], themes: [],
+        contradictions: [], keyInsights: [], bottomLine: 'Refused analysis',
+      },
+      provenance: { aiProvider: 'gemini', aiModel: 'gemini-3.7-flash', requestedAiModel: 'gemini-3.7-flash' },
+      studyRevision: 1,
+    }, redis)).toEqual({ status: 'corrupt' });
+    expect(await redis.get(`interview:${interview.id}`)).toBe(encoded);
+    expect(await recordInterviewAnalysisFailure(interview.id, 'claim-held', 'provider', redis))
+      .toEqual({ status: 'corrupt' });
+    expect(await redis.get(`interview:${interview.id}`)).toBe(encoded);
+  });
+
+  it('refuses a record with a non-numeric identity timestamp as corrupt without changing it', async () => {
+    const interview = makeStoredInterview({ id: `interview-${uuid()}` });
+    const encoded = `oi:interview:${JSON.stringify({ ...interview, createdAt: String(NOW) })}`;
+    await redis.set(`interview:${interview.id}`, encoded);
+    expect(await claimInterviewAnalysis(interview.id, redis, NOW)).toEqual({ status: 'corrupt' });
+    expect(await redis.get(`interview:${interview.id}`)).toBe(encoded);
+  });
+
+  it('still claims a legacy record that has no analysis member and starts its counter at one', async () => {
+    const interview = makeStoredInterview({ id: `interview-${uuid()}` });
+    const record = { ...interview } as Record<string, unknown>;
+    delete record.analysis;
+    expect(record).not.toHaveProperty('analysis');
+    await redis.set(`interview:${interview.id}`, `oi:interview:${JSON.stringify(record)}`);
+    const claim = await claimInterviewAnalysis(interview.id, redis, NOW);
+    expect(claim).toMatchObject({ status: 'claimed', attempts: 1 });
+    const stored = await getInterviewChecked(interview.id, redis);
+    expect(stored.status === 'found' && stored.interview.analysis).toMatchObject({
+      status: 'running', attempts: 1, lastAttemptAt: NOW,
+    });
   });
 
   it('claim then attach on a record with an empty array and an empty string round-trips both byte-identically', async () => {

--- a/tests/smoke/provider-provenance.smoke.test.ts
+++ b/tests/smoke/provider-provenance.smoke.test.ts
@@ -1,0 +1,138 @@
+// Live-provider provenance smoke: one paid synthesizeInterview call through
+// the real adapter, to confirm the served response carries a non-blank
+// `model` (execution() in providers/shared.ts throws otherwise).
+//
+// Scope, deliberately narrow:
+// - Skipped entirely unless SMOKE_PROVIDER names one provider.
+// - Direct transport and standalone mode are forced; no Redis client is
+//   constructed and nothing is read from or written to any store.
+// - Synthetic study and transcript only. Output: provider, requested model,
+//   served model, routed provider, and a failure class. Never the synthesis
+//   body, never a raw response, never a key.
+// - One adapter invocation. The SDKs' own retry defaults are not overridden
+//   here (Anthropic and OpenAI SDKs retry up to 2 times on transient
+//   failures, so a single invocation may be up to 3 HTTP requests). Output
+//   caps come from the adapter: 8192 tokens for the synthesis call.
+//
+// Usage (one provider, one credential):
+//   SMOKE_PROVIDER=openai OPENAI_API_KEY="$(op read 'op://…')" \
+//     npx vitest run --config vitest.smoke.config.mts
+// Optional: SMOKE_MODEL to override the provider's default model.
+
+import { describe, expect, it } from 'vitest';
+import { getInterviewProvider, isProviderType } from '@/lib/providers';
+import { ProviderFailure, ProviderTimeoutError } from '@/lib/providerErrors';
+import {
+  DEFAULT_CLAUDE_MODEL,
+  DEFAULT_GEMINI_MODEL,
+  DEFAULT_OPENAI_MODEL,
+  DEFAULT_OPENROUTER_MODEL,
+  type BehaviorData,
+  type InterviewMessage,
+  type StudyConfig,
+} from '@/types';
+
+const selected = process.env.SMOKE_PROVIDER?.trim() ?? '';
+const provider = isProviderType(selected) ? selected : null;
+
+const DEFAULT_MODEL: Record<string, string> = {
+  gemini: DEFAULT_GEMINI_MODEL,
+  claude: DEFAULT_CLAUDE_MODEL,
+  openai: DEFAULT_OPENAI_MODEL,
+  openrouter: DEFAULT_OPENROUTER_MODEL,
+};
+
+const KEY_ENV: Record<string, string> = {
+  gemini: 'GEMINI_API_KEY',
+  claude: 'ANTHROPIC_API_KEY',
+  openai: 'OPENAI_API_KEY',
+  openrouter: 'OPENROUTER_API_KEY',
+};
+
+function syntheticStudy(aiProvider: StudyConfig['aiProvider'], aiModel: string): StudyConfig {
+  return {
+    id: 'smoke-study',
+    name: 'Smoke study',
+    description: 'Synthetic study for a provenance smoke test.',
+    researchQuestion: 'How do people decide when to replace a worn-out kitchen tool?',
+    coreQuestions: [
+      'What was the last kitchen tool you replaced?',
+      'What made you decide it was time?',
+      'Did anything about the replacement surprise you?',
+    ],
+    topicAreas: ['Replacement triggers', 'Purchase decision'],
+    profileSchema: [
+      { id: 'role', label: 'Cooking frequency', extractionHint: 'How often they cook', required: false },
+    ],
+    aiBehavior: 'standard',
+    aiProvider,
+    aiModel,
+    consentText: 'Synthetic consent.',
+    createdAt: 1_700_000_000_000,
+  };
+}
+
+const TRANSCRIPT: InterviewMessage[] = [
+  { id: 'm1', role: 'ai', content: 'What was the last kitchen tool you replaced?', timestamp: 1_700_000_000_000 },
+  { id: 'm2', role: 'user', content: 'A non-stick frying pan. The coating had started flaking.', timestamp: 1_700_000_010_000 },
+  { id: 'm3', role: 'ai', content: 'What made you decide it was time?', timestamp: 1_700_000_020_000 },
+  { id: 'm4', role: 'user', content: 'Eggs kept sticking, and I read that flaking coating is not great to eat. I put it off for a month though.', timestamp: 1_700_000_030_000 },
+];
+
+const BEHAVIOR: BehaviorData = {
+  timePerTopic: {},
+  messagesPerTopic: {},
+  topicsExplored: ['Replacement triggers'],
+  contradictions: [],
+};
+
+describe.skipIf(!provider)('live provider provenance smoke', () => {
+  it(`${provider ?? '(none)'}: synthesizeInterview returns a served model`, async () => {
+    if (!provider) return;
+    // Force the transport and mode this smoke is about; never inherit a
+    // Gateway or hosted configuration from the shell.
+    process.env.AI_TRANSPORT = 'direct';
+    process.env.DEPLOYMENT_MODE = 'standalone';
+
+    const keyEnv = KEY_ENV[provider];
+    if (!process.env[keyEnv]?.trim()) {
+      throw new Error(`${keyEnv} is not set; inject only this provider's credential`);
+    }
+    for (const [other, env] of Object.entries(KEY_ENV)) {
+      if (other !== provider && process.env[env]?.trim()) {
+        throw new Error(`${env} is also set; run with exactly one provider credential`);
+      }
+    }
+
+    const model = process.env.SMOKE_MODEL?.trim() || DEFAULT_MODEL[provider];
+    const study = syntheticStudy(provider, model);
+    const adapter = getInterviewProvider(study, {});
+
+    try {
+      const result = await adapter.synthesizeInterview(TRANSCRIPT, study, BEHAVIOR, null);
+      const { execution } = result;
+      console.log(JSON.stringify({
+        smoke: 'provider-provenance',
+        provider: execution.provider,
+        requestedModel: execution.requestedModel,
+        servedModel: execution.model,
+        ...(execution.routedProvider ? { routedProvider: execution.routedProvider } : {}),
+        themes: result.value.themes.length,
+      }));
+      expect(execution.provider).toBe(provider);
+      expect(execution.requestedModel).toBe(model);
+      expect(execution.model.trim().length).toBeGreaterThan(0);
+    } catch (error) {
+      // Report the class only. A missing served model surfaces here as
+      // ProviderFailure kind 'invalid-response' — that is the finding this
+      // smoke exists to detect; do not retry, bring the class back.
+      const failure = error instanceof ProviderFailure
+        ? { class: 'ProviderFailure', kind: error.kind, message: error.message }
+        : error instanceof ProviderTimeoutError
+          ? { class: 'ProviderTimeoutError' }
+          : { class: error instanceof Error ? error.name : 'UnknownError' };
+      console.log(JSON.stringify({ smoke: 'provider-provenance', provider, requestedModel: model, failure }));
+      throw error;
+    }
+  });
+});

--- a/tests/unit/interviewAnalysis.idempotent.test.ts
+++ b/tests/unit/interviewAnalysis.idempotent.test.ts
@@ -22,6 +22,12 @@ vi.mock('@/lib/providers', () => ({
   getInterviewProvider: vi.fn(() => ({ synthesizeInterview })),
 }));
 
+const logRequestEvent = vi.hoisted(() => vi.fn());
+vi.mock('@/lib/requestLog', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/lib/requestLog')>()),
+  logRequestEvent,
+}));
+
 import { runInterviewAnalysis } from '@/lib/interviewAnalysis';
 
 const study = { ...makeStudyConfig(), aiProvider: 'gemini' as const, aiModel: 'gemini-3.7-flash' };
@@ -220,5 +226,54 @@ describe('runInterviewAnalysis: failure classification', () => {
 
     expect(result).toEqual({ status: 'unavailable' });
     expect(kvMock.recordInterviewAnalysisFailure).toHaveBeenCalledWith('interview-a', 'claim-1', 'storage', {});
+  });
+});
+
+describe('runInterviewAnalysis: corrupt stored analysis state', () => {
+  const corruptLog = () => logRequestEvent.mock.calls
+    .map(([event]) => event as Record<string, unknown>)
+    .filter(event => event.event === 'interview.analysis');
+
+  it('a corrupt claim is reported as unavailable, logged as corrupt-record, and makes no provider call or write', async () => {
+    kvMock.claimInterviewAnalysis.mockResolvedValue({ status: 'corrupt' });
+
+    const result = await runInterviewAnalysis(baseInput());
+
+    expect(result).toEqual({ status: 'unavailable' });
+    expect(synthesizeInterview).not.toHaveBeenCalled();
+    expect(kvMock.recordInterviewAnalysisFailure).not.toHaveBeenCalled();
+    expect(corruptLog()).toEqual([expect.objectContaining({ reason: 'corrupt-record', status: 503 })]);
+  });
+
+  it('a corrupt attach returns immediately without a failure-marker write', async () => {
+    kvMock.claimInterviewAnalysis.mockResolvedValue({ status: 'claimed', claimId: 'claim-1', attempts: 1 });
+    synthesizeInterview.mockResolvedValue(providerResult());
+    kvMock.attachInterviewAnalysis.mockResolvedValue({ status: 'corrupt' });
+
+    const result = await runInterviewAnalysis(baseInput());
+
+    expect(result).toEqual({ status: 'unavailable' });
+    expect(kvMock.recordInterviewAnalysisFailure).not.toHaveBeenCalled();
+    expect(corruptLog()).toEqual([expect.objectContaining({ reason: 'corrupt-record', status: 503 })]);
+  });
+
+  it('a corrupt failure-marker write is reported as unavailable, not as a recorded provider failure', async () => {
+    kvMock.claimInterviewAnalysis.mockResolvedValue({ status: 'claimed', claimId: 'claim-1', attempts: 1 });
+    synthesizeInterview.mockRejectedValue(new Error('provider down'));
+    kvMock.recordInterviewAnalysisFailure.mockResolvedValue({ status: 'corrupt' });
+
+    const result = await runInterviewAnalysis(baseInput());
+
+    expect(result).toEqual({ status: 'unavailable' });
+    expect(kvMock.recordInterviewAnalysisFailure).toHaveBeenCalledTimes(1);
+    expect(corruptLog()).toEqual([expect.objectContaining({ reason: 'corrupt-record', status: 503 })]);
+  });
+
+  it('never puts record contents in the log', async () => {
+    kvMock.claimInterviewAnalysis.mockResolvedValue({ status: 'corrupt' });
+    await runInterviewAnalysis(baseInput());
+    for (const event of corruptLog()) {
+      expect(Object.keys(event).sort()).toEqual(['event', 'operation', 'reason', 'route', 'status']);
+    }
   });
 });

--- a/tests/unit/kv.analysisAttach.test.ts
+++ b/tests/unit/kv.analysisAttach.test.ts
@@ -56,6 +56,8 @@ describe('kv.analysisAttach: claimInterviewAnalysis', () => {
       .resolves.toEqual({ status: 'already-complete' });
     await expect(claimInterviewAnalysis('interview-a', client('oi:analysis-notfound')))
       .resolves.toEqual({ status: 'not-found' });
+    await expect(claimInterviewAnalysis('interview-a', client('oi:analysis-corrupt')))
+      .resolves.toEqual({ status: 'corrupt' });
   });
 
   it('maps an unknown tag to unavailable', async () => {
@@ -130,6 +132,7 @@ describe('kv.analysisAttach: attachInterviewAnalysis', () => {
     await expect(attachInterviewAnalysis(input, client('oi:analysis-done'))).resolves.toEqual({ status: 'already-complete' });
     await expect(attachInterviewAnalysis(input, client('oi:analysis-stale'))).resolves.toEqual({ status: 'stale' });
     await expect(attachInterviewAnalysis(input, client('oi:analysis-notfound'))).resolves.toEqual({ status: 'not-found' });
+    await expect(attachInterviewAnalysis(input, client('oi:analysis-corrupt'))).resolves.toEqual({ status: 'corrupt' });
   });
 
   it('maps an unknown wire tag to unavailable', async () => {
@@ -162,5 +165,15 @@ describe('kv.analysisAttach: recordInterviewAnalysisFailure', () => {
     await expect(recordInterviewAnalysisFailure('interview-a', 'claim-1', 'provider', client))
       .resolves.toEqual({ status: 'written' });
     expect(client.get).not.toHaveBeenCalled();
+  });
+
+  it('maps oi:analysis-corrupt to corrupt, distinct from unavailable', async () => {
+    const client = {
+      get: vi.fn(),
+      eval: vi.fn().mockResolvedValue(['oi:analysis-corrupt']),
+    } as unknown as RedisPort;
+
+    await expect(recordInterviewAnalysisFailure('interview-a', 'claim-1', 'provider', client))
+      .resolves.toEqual({ status: 'corrupt' });
   });
 });

--- a/tests/unit/requestLog.test.ts
+++ b/tests/unit/requestLog.test.ts
@@ -126,6 +126,14 @@ describe('logRequestEvent allowlist', () => {
     expect(JSON.stringify(spy.mock.calls)).not.toContain('leaked');
   });
 
+  it('accepts the corrupt-record reason', () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    logRequestEvent({ event: 'interview.analysis', reason: 'corrupt-record', status: 503 });
+    const payload = parseLogged(spy);
+    expect(payload.reason).toBe('corrupt-record');
+    expect(payload.status).toBe(503);
+  });
+
   it('rejects unknown event names and unknown reasons', () => {
     const spy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
     logRequestEvent({ event: 'study.123@example.com', reason: 'please retry later' });

--- a/tests/unit/wire.analysis.test.ts
+++ b/tests/unit/wire.analysis.test.ts
@@ -13,6 +13,12 @@ describe('wire.analysis: parseAnalysisResult', () => {
     expect(parseAnalysisResult(['oi:analysis-stale'])).toEqual({ status: 'ok', value: { outcome: 'stale' } });
     expect(parseAnalysisResult(['oi:analysis-written'])).toEqual({ status: 'ok', value: { outcome: 'written' } });
     expect(parseAnalysisResult(['oi:analysis-recorded'])).toEqual({ status: 'ok', value: { outcome: 'recorded' } });
+    expect(parseAnalysisResult(['oi:analysis-corrupt'])).toEqual({ status: 'ok', value: { outcome: 'corrupt' } });
+  });
+
+  it('keeps corrupt distinct from the unavailable marker and rejects a payload on it', () => {
+    expect(parseAnalysisResult(['oi:analysis-corrupt'])).not.toEqual({ status: 'unavailable' });
+    expect(parseAnalysisResult(['oi:analysis-corrupt', 'extra'])).toEqual({ status: 'unavailable' });
   });
 
   it('maps the claimed tag with the atomic attempt count', () => {

--- a/vitest.smoke.config.mts
+++ b/vitest.smoke.config.mts
@@ -1,0 +1,19 @@
+// Live-provider smoke config. Never part of `npm run check`; run explicitly
+// with a single provider selected and only that provider's credential in the
+// environment. See tests/smoke/provider-provenance.smoke.test.ts.
+import { fileURLToPath } from 'node:url';
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['tests/smoke/**/*.smoke.test.ts'],
+    testTimeout: 150_000,
+    hookTimeout: 30_000,
+  },
+  resolve: {
+    alias: {
+      '@': fileURLToPath(new URL('./src', import.meta.url)),
+    },
+  },
+});


### PR DESCRIPTION
Follow-ups from the 2026-09-06 maintenance review (#26).

## Corrupt-record diagnosis
The attach script's structural gates returned the same `oi:analysis-unavailable` as a transport failure. They now return a new closed-family tag `oi:analysis-corrupt`, mapped explicitly at claim, attach, and failure recording. The pipeline logs `reason: corrupt-record` at status 503 and returns `unavailable`, so the public response is unchanged; a corrupt attach returns without a second write. Exhausted counter stays `unavailable`.

Real-Redis coverage: malformed/missing `attempts`, running claim without `lastAttemptAt` (attach and fail), string `createdAt` — all refused with the record byte-for-byte unchanged; legacy record with no `analysis` member still claims at `attempts: 1`.

## Live-provider smoke runner
`tests/smoke/provider-provenance.smoke.test.ts` + `vitest.smoke.config.mts`: gated on `SMOKE_PROVIDER`, refuses if any other provider key is present, forces direct/standalone, no store client, reports metadata and failure class only. Excluded from `npm run check`.

**Gemini verified live:** requested `gemini-3.7-flash`, served `gemini-3.7-flash`, 3 themes. Claude/OpenAI/OpenRouter not yet run.

## Verification
- `npm run check`: lint, typecheck, 1,576 unit tests
- `npm run test:redis-crash`: 34 tests on owned disposable Redis
- `git diff --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FHTUSbFSJPXnTtJuHVRmj5