### PR TITLE
Document corrupt-record diagnosis and the live-provider smoke tier

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,6 +61,8 @@ The sample-workspace seed is not the public demo. `/demo` is component-memory-on
 - Cross-database study-operation repair: `src/lib/studyOperationReconciler.ts`
 - Disposable Redis fault harness: `tests/helpers/disposableRedis.ts`, `tests/helpers/faultManifest.ts`
 
+The interview analysis attach script distinguishes two non-writes: `unavailable` (transport or transient; retryable) and `corrupt` (the stored record's identity members or `analysis` state are not the shape the script owns). A corrupt record is never patched, is logged as `reason: corrupt-record`, and is reported to callers as `unavailable` so the researcher response stays retryable. Keep the two tags separate; folding `corrupt` into `unavailable` hides record faults behind outage alerts.
+
 Hosted study create/delete is a durable cross-database operation. Preserve the operation marker/tombstone and reconciliation protocol; a superficially simpler sequence can reintroduce orphaned ownership or BYOS records.
 
 ### Participant and AI flow
@@ -114,6 +116,8 @@ The participant sequence is link exchange -> HttpOnly participant session -> con
 | Design system | `src/components/ui/`, `src/app/globals.css`, `tailwind.config.ts`, `eslint.config.mjs` | `tests/unit/ui.*.test.tsx`; new visual vocabulary is added as a primitive here, never inline in a screen; changes follow a `docs/design/slice-*-spec.md` |
 
 Vitest tests live in two tiers. `tests/unit/` runs under the base vitest config (jsdom) and mirrors the security or product boundary it protects; prefer a realistic regression at that boundary over snapshots of implementation detail. `tests/integration/` runs under `vitest.integration.config.mts` (node environment) against a runner-owned disposable `redis-server` via `tests/helpers/disposableRedis.ts` — it must never connect to an inherited, shared, or production Redis. Use `npm run test:redis-crash` and `npm run test:adversarial` for these suites; they need a local `redis-server` binary (or the CI container) and are the only place real-wire crash-cut and cross-tenant claims are actually exercised.
+
+`tests/smoke/` is a third, paid tier and is excluded from `npm run check`: `vitest.smoke.config.mts` runs one live `synthesizeInterview` through the real direct adapter to confirm the served response names a model. It is gated on `SMOKE_PROVIDER`, refuses if any other provider credential is present, forces direct transport and standalone mode, constructs no store client, and reports metadata or a failure class only. Run it when a provider adapter, SDK, or the provenance requirement changes; fixtures cannot establish live-provider compatibility.
 
 `tests/e2e/` runs the browser journeys with real application API handlers and disposable Redis; only external provider HTTP responses are synthetic. `tests/e2e/server.mjs` builds and boots the production app with a blank, credential-free fixture environment (one server per transport) and `tests/e2e/workflow-fixture.ts` intercepts Upstash and provider HTTP at Next's test-mode boundary — together they are the sanctioned way to exercise the full researcher and participant workflow locally without any real credentials. Keep the Next test proxy confined to its test-only server launcher. Do not mock internal save/analyze APIs in the completion regression: it must exercise transcript persistence, deferred analysis, and researcher recovery across that boundary. The keyless demo regression still requires no API or external requests.
 

--- a/README.md
+++ b/README.md
@@ -300,7 +300,15 @@ git diff --check
 
 The browser suite covers the keyless demo plus standalone direct and Gateway research workflows: study creation, participant-link exchange, consent, interview, saving, deferred analysis, researcher recovery and review, and export. The workflow tests run the real application APIs with synthetic provider HTTP responses and a fresh disposable Redis instance per test. They require Docker or a local `redis-server`; inherited `REDIS_URL` or Redis attestation configuration is refused. Test-only servers use fixture credentials and Next's test proxy; the deployed application does not enable that proxy. These tests verify application behavior, not live provider availability, model quality, or hosted OAuth onboarding.
 
-Production logs are allowlisted JSON and never contain prompts, keys, or bodies. Real-Redis crash and shared-BYOS adversarial jobs also refuse inherited production Redis connections.
+Production logs are allowlisted JSON and never contain prompts, keys, or bodies. An `interview.analysis` event with `reason: corrupt-record` means a stored interview record was refused for structural reasons and left unchanged; it is not a Redis outage (`reason: unavailable`) and will not resolve by retrying. Real-Redis crash and shared-BYOS adversarial jobs also refuse inherited production Redis connections.
+
+Live-provider compatibility is a separate, paid check that the fixture suites cannot make. `tests/smoke/provider-provenance.smoke.test.ts` runs one real synthesis call through the direct adapter for a single provider and confirms the served response names a model:
+
+```bash
+SMOKE_PROVIDER=gemini GEMINI_API_KEY=... npx vitest run --config vitest.smoke.config.mts
+```
+
+It refuses to run with more than one provider credential present, writes nothing, and prints only provider, requested and served model, and a failure class.
 
 For ordinary updates to an already configured deployment, use a reviewed pull request, require the CI and preview checks, merge to `main`, then verify the exact Git-backed production deployment on the canonical domain and scan runtime errors. The longer runbook above is for the first hosted-mode infrastructure cutover, not every application release.
 

--- a/docs/maintenance-review-2026-09-06.md
+++ b/docs/maintenance-review-2026-09-06.md
@@ -84,3 +84,33 @@ The work is isolated on `codex/maintenance-review-20260906` at
 `/Users/xulelin/.codex/worktrees/openinterviewer-review-20260906`. The original
 checkout's untracked duplicate files and user-owned `.claude/` directory were
 preserved. No credentials, external data, push, merge, or deployment were involved.
+
+## Follow-up (same day, PR #27, `6bcb5b0`)
+
+A second review of the merged diffs, made after `c92af80` was deployed, agreed
+with the fixes and raised two gaps:
+
+- The new served-model requirement had been verified only against fixtures.
+  `execution()` is used solely by synthesis, aggregate, and follow-up, so the
+  live participant interview was never at risk; researcher-side analysis was.
+- The attach script's new structural gates returned the same
+  `oi:analysis-unavailable` as a transport failure, so a malformed record was
+  indistinguishable from an outage in logs.
+
+Two corrections to that second review were accepted: the five-to-three
+command count already included the post-claim read, and the identity checks
+had moved from `decodeStoredInterview()` into the script rather than being new.
+
+Changes: `oi:analysis-corrupt` as a new closed-family tag, mapped explicitly at
+claim, attach, and failure recording; logged as `reason: corrupt-record` at
+503 and returned as `unavailable`, so the public response is unchanged; a
+corrupt attach makes no second write. Real-Redis coverage asserts refused
+records are byte-for-byte unchanged and legacy records still claim. A gated,
+single-credential live smoke runner was added under `tests/smoke/`.
+
+Verification: `npm run check` (1,576 unit tests), `npm run test:redis-crash`
+(34), `git diff --check`. Live smoke, Gemini only: requested and served
+`gemini-3.7-flash`, two calls, direct transport, standalone mode, no store
+client. Gemini echoes the alias rather than a dated snapshot, so the check is
+satisfied but not discriminating there. Claude, OpenAI, and OpenRouter remain
+unverified live.


### PR DESCRIPTION
Documents PR #27: the corrupt/unavailable distinction in the attach script, the corrupt-record log reason, and the gated paid smoke tier. Appends the follow-up record to the 2026-09-06 review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FHTUSbFSJPXnTtJuHVRmj5