### PR TITLE
Sanitize the live smoke's failure boundary and correct its output-cap note

### DIFF
--- a/tests/smoke/provider-provenance.smoke.test.ts
+++ b/tests/smoke/provider-provenance.smoke.test.ts
@@ -12,7 +12,9 @@
 // - One adapter invocation. The SDKs' own retry defaults are not overridden
 //   here (Anthropic and OpenAI SDKs retry up to 2 times on transient
 //   failures, so a single invocation may be up to 3 HTTP requests). Output
-//   caps come from the adapter: 8192 tokens for the synthesis call.
+//   caps are whatever the adapter's synthesis call sets: 8192 tokens for
+//   Claude, OpenAI, and OpenRouter; the Gemini adapter sets no explicit cap.
+// - On failure the original error is never rethrown: see smokeFailure.ts.
 //
 // Usage (one provider, one credential):
 //   SMOKE_PROVIDER=openai OPENAI_API_KEY="$(op read 'op://…')" \
@@ -21,7 +23,7 @@
 
 import { describe, expect, it } from 'vitest';
 import { getInterviewProvider, isProviderType } from '@/lib/providers';
-import { ProviderFailure, ProviderTimeoutError } from '@/lib/providerErrors';
+import { classifySmokeFailure, sanitizedSmokeError } from './smokeFailure';
 import {
   DEFAULT_CLAUDE_MODEL,
   DEFAULT_GEMINI_MODEL,
@@ -123,16 +125,13 @@ describe.skipIf(!provider)('live provider provenance smoke', () => {
       expect(execution.requestedModel).toBe(model);
       expect(execution.model.trim().length).toBeGreaterThan(0);
     } catch (error) {
-      // Report the class only. A missing served model surfaces here as
-      // ProviderFailure kind 'invalid-response' — that is the finding this
-      // smoke exists to detect; do not retry, bring the class back.
-      const failure = error instanceof ProviderFailure
-        ? { class: 'ProviderFailure', kind: error.kind, message: error.message }
-        : error instanceof ProviderTimeoutError
-          ? { class: 'ProviderTimeoutError' }
-          : { class: error instanceof Error ? error.name : 'UnknownError' };
+      // Report the class and kind only, then throw a fresh error carrying
+      // nothing else. A missing served model surfaces as
+      // ProviderFailure/invalid-response — the finding this smoke exists to
+      // detect; do not retry, bring the class back.
+      const failure = classifySmokeFailure(error);
       console.log(JSON.stringify({ smoke: 'provider-provenance', provider, requestedModel: model, failure }));
-      throw error;
+      throw sanitizedSmokeError(failure);
     }
   });
 });

--- a/tests/smoke/smokeFailure.ts
+++ b/tests/smoke/smokeFailure.ts
@@ -1,0 +1,33 @@
+// The smoke runner's failure boundary. Anything thrown by an adapter may carry
+// the SDK's response on `cause` or as attached properties, and a validation
+// failure's message may quote model output. Vitest prints thrown errors in
+// full, so the runner must never rethrow the original. This module reduces a
+// failure to an allowlisted class and kind, and mints a fresh Error with no
+// cause, no extra properties, and a message built only from those two fields.
+
+import { ProviderFailure, ProviderTimeoutError } from '@/lib/providerErrors';
+
+export type SmokeFailure =
+  | { class: 'ProviderFailure'; kind: ProviderFailure['kind'] }
+  | { class: 'ProviderTimeoutError' }
+  | { class: 'ValidationError' | 'UnknownError' };
+
+const KINDS = new Set<ProviderFailure['kind']>(['unavailable', 'rate-limited', 'config', 'invalid-response']);
+
+/** Classify without reading message, cause, or any attached property. */
+export function classifySmokeFailure(error: unknown): SmokeFailure {
+  if (error instanceof ProviderFailure) {
+    return { class: 'ProviderFailure', kind: KINDS.has(error.kind) ? error.kind : 'unavailable' };
+  }
+  if (error instanceof ProviderTimeoutError) return { class: 'ProviderTimeoutError' };
+  if (error instanceof Error && error.name === 'ValidationError') return { class: 'ValidationError' };
+  return { class: 'UnknownError' };
+}
+
+/** A fresh error whose every observable surface is derived from the class and kind alone. */
+export function sanitizedSmokeError(failure: SmokeFailure): Error {
+  const label = failure.class === 'ProviderFailure' ? `${failure.class}/${failure.kind}` : failure.class;
+  const error = new Error(`live provider smoke failed: ${label}`);
+  error.name = 'SmokeFailure';
+  return error;
+}

--- a/tests/unit/smokeFailure.test.ts
+++ b/tests/unit/smokeFailure.test.ts
@@ -1,0 +1,90 @@
+// @vitest-environment node
+
+// Offline regression for the live smoke's failure boundary: whatever an
+// adapter throws, nothing from its response can reach the runner's output.
+// The sanitized error is what Vitest prints, so every surface a reporter
+// reads (message, name, stack, own properties, cause, JSON, inspect) is
+// checked for the planted markers.
+
+import { inspect } from 'node:util';
+import { describe, expect, it } from 'vitest';
+import { ProviderFailure, ProviderTimeoutError } from '@/lib/providerErrors';
+import { classifySmokeFailure, sanitizedSmokeError } from '../smoke/smokeFailure';
+
+const BODY_MARKER = 'RESPONSE_BODY_MARKER_9f1c';
+const HEADER_MARKER = 'Bearer sk-HEADER_MARKER_2b7e';
+const OUTPUT_MARKER = 'MODEL_OUTPUT_MARKER_44aa';
+
+function sdkLikeCause() {
+  const cause = new Error(`400 ${BODY_MARKER}`) as Error & Record<string, unknown>;
+  cause.status = 400;
+  cause.headers = { authorization: HEADER_MARKER };
+  cause.response = { body: `{"error":"${BODY_MARKER}"}`, text: BODY_MARKER };
+  cause.error = { message: BODY_MARKER, output: OUTPUT_MARKER };
+  return cause;
+}
+
+function everySurface(error: Error): string {
+  return [
+    error.message,
+    error.name,
+    error.stack ?? '',
+    JSON.stringify(error),
+    JSON.stringify(Object.getOwnPropertyNames(error).map(key => (error as unknown as Record<string, unknown>)[key])),
+    inspect(error, { depth: 10, showHidden: true }),
+    String((error as { cause?: unknown }).cause),
+  ].join('\n');
+}
+
+describe('smokeFailure: classification reads no error content', () => {
+  it('maps a ProviderFailure to its kind and everything else to a class', () => {
+    expect(classifySmokeFailure(new ProviderFailure('invalid-response', BODY_MARKER, sdkLikeCause())))
+      .toEqual({ class: 'ProviderFailure', kind: 'invalid-response' });
+    expect(classifySmokeFailure(new ProviderTimeoutError(1))).toEqual({ class: 'ProviderTimeoutError' });
+    const validation = new Error(OUTPUT_MARKER);
+    validation.name = 'ValidationError';
+    expect(classifySmokeFailure(validation)).toEqual({ class: 'ValidationError' });
+    expect(classifySmokeFailure({ response: BODY_MARKER })).toEqual({ class: 'UnknownError' });
+    expect(classifySmokeFailure(BODY_MARKER)).toEqual({ class: 'UnknownError' });
+  });
+
+  it('falls back to unavailable for a kind outside the allowlist', () => {
+    const failure = new ProviderFailure('unavailable', 'x');
+    (failure as { kind: string }).kind = BODY_MARKER;
+    expect(classifySmokeFailure(failure)).toEqual({ class: 'ProviderFailure', kind: 'unavailable' });
+  });
+});
+
+describe('smokeFailure: the thrown error carries nothing from the original', () => {
+  const originals: unknown[] = [
+    new ProviderFailure('invalid-response', `gemini synthesis ${BODY_MARKER}`, sdkLikeCause()),
+    new ProviderFailure('unavailable', OUTPUT_MARKER, { response: { body: BODY_MARKER } }),
+    new ProviderTimeoutError(5, BODY_MARKER),
+    Object.assign(new Error(BODY_MARKER), { name: 'ValidationError', output: OUTPUT_MARKER }),
+    Object.assign(new Error(BODY_MARKER), { cause: sdkLikeCause(), response: sdkLikeCause() }),
+    sdkLikeCause(),
+    { message: BODY_MARKER, response: { body: BODY_MARKER } },
+    BODY_MARKER,
+  ];
+
+  it.each(originals.map((original, index) => [index, original] as const))(
+    'original %i: no response-body, header, or output marker on any reporter-visible surface',
+    (_index, original) => {
+      const sanitized = sanitizedSmokeError(classifySmokeFailure(original));
+      const surface = everySurface(sanitized);
+      expect(surface).not.toContain(BODY_MARKER);
+      expect(surface).not.toContain(HEADER_MARKER);
+      expect(surface).not.toContain(OUTPUT_MARKER);
+      expect((sanitized as { cause?: unknown }).cause).toBeUndefined();
+      expect(Object.getOwnPropertyNames(sanitized).sort()).toEqual(['message', 'name', 'stack']);
+      expect(sanitized).not.toBe(original);
+    },
+  );
+
+  it('names the class and kind so the finding is still readable', () => {
+    expect(sanitizedSmokeError({ class: 'ProviderFailure', kind: 'invalid-response' }).message)
+      .toBe('live provider smoke failed: ProviderFailure/invalid-response');
+    expect(sanitizedSmokeError({ class: 'ProviderTimeoutError' }).message)
+      .toBe('live provider smoke failed: ProviderTimeoutError');
+  });
+});


### PR DESCRIPTION
Addresses Codex's review of #27: the smoke runner rethrew the original adapter error (cause/attached properties can carry the SDK response; message can quote model output). It now throws a fresh error built from class and kind only. Offline regression `tests/unit/smokeFailure.test.ts` plants markers on eight error shapes and checks message, name, stack, own properties, cause, JSON, and inspect. End-to-end check under the verbose reporter: 0 marker occurrences. Output-cap note corrected: 8192 for Claude/OpenAI/OpenRouter, Gemini none.

No provider calls made.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FHTUSbFSJPXnTtJuHVRmj5